### PR TITLE
Fix OAuth refresh: send form-encoded body (not query params) to token endpoint

### DIFF
--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -111,51 +111,6 @@ class CharmHealthAPIClient:
             return await self._refresh_token()
     
 
-    # async def _refresh_token(self) -> str:
-    #     logger.info("Refreshing CharmHealth API token")
-    #     headers = {'Content-Type': 'application/json'}
-    #     params = {
-    #         'refresh_token': self.refresh_token,
-    #         'client_id': self.client_id,
-    #         'client_secret': self.client_secret,
-    #         'redirect_uri': self.redirect_uri,
-    #         'grant_type': 'refresh_token',
-    #     }
-
-    #     async with httpx.AsyncClient() as client:
-    #         try:
-    #             response = await client.post(
-    #                 self.token_url,
-    #                 params=params,
-    #                 headers=headers,
-    #                 timeout=self.timeout
-    #             )
-    #             current_time = time.time()
-    #             response.raise_for_status()
-    #             token_data = response.json()
-    #             new_token = token_data.get('access_token')
-    #             expires_in = token_data.get('expires_in', 3600)
-    #             if not new_token:
-    #                 raise ValueError(f"Failed to obtain new token with response: {response.text}")
-
-    #             self._auth_token = new_token
-    #             self._token_expires_at = current_time + expires_in
-
-    #             key = self._token_cache_key()
-    #             self.__class__._shared_token_cache[key] = {
-    #                 "token": new_token,
-    #                 "expires_at": self._token_expires_at,
-    #             }
-
-    #             scopes = token_data.get('scope', '')
-    #             scope_count = len(scopes.split()) if isinstance(scopes, str) else 0
-    #             logger.info(f"Token refreshed successfully (expires_in={expires_in}s, scopes={scope_count})")
-    #             return new_token
-
-    #         except Exception as e:
-    #             logger.error(f"Failed to refresh token: {e} with response: {response.text}")
-    #             raise
-
     async def _refresh_token(self) -> str:
         logger.info("Refreshing CharmHealth API token")
         headers = {

--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -111,10 +111,58 @@ class CharmHealthAPIClient:
             return await self._refresh_token()
     
 
+    # async def _refresh_token(self) -> str:
+    #     logger.info("Refreshing CharmHealth API token")
+    #     headers = {'Content-Type': 'application/json'}
+    #     params = {
+    #         'refresh_token': self.refresh_token,
+    #         'client_id': self.client_id,
+    #         'client_secret': self.client_secret,
+    #         'redirect_uri': self.redirect_uri,
+    #         'grant_type': 'refresh_token',
+    #     }
+
+    #     async with httpx.AsyncClient() as client:
+    #         try:
+    #             response = await client.post(
+    #                 self.token_url,
+    #                 params=params,
+    #                 headers=headers,
+    #                 timeout=self.timeout
+    #             )
+    #             current_time = time.time()
+    #             response.raise_for_status()
+    #             token_data = response.json()
+    #             new_token = token_data.get('access_token')
+    #             expires_in = token_data.get('expires_in', 3600)
+    #             if not new_token:
+    #                 raise ValueError(f"Failed to obtain new token with response: {response.text}")
+
+    #             self._auth_token = new_token
+    #             self._token_expires_at = current_time + expires_in
+
+    #             key = self._token_cache_key()
+    #             self.__class__._shared_token_cache[key] = {
+    #                 "token": new_token,
+    #                 "expires_at": self._token_expires_at,
+    #             }
+
+    #             scopes = token_data.get('scope', '')
+    #             scope_count = len(scopes.split()) if isinstance(scopes, str) else 0
+    #             logger.info(f"Token refreshed successfully (expires_in={expires_in}s, scopes={scope_count})")
+    #             return new_token
+
+    #         except Exception as e:
+    #             logger.error(f"Failed to refresh token: {e} with response: {response.text}")
+    #             raise
+
     async def _refresh_token(self) -> str:
         logger.info("Refreshing CharmHealth API token")
-        headers = {'Content-Type': 'application/json'}
-        params = {
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json',
+        }
+        form = {
             'refresh_token': self.refresh_token,
             'client_id': self.client_id,
             'client_secret': self.client_secret,
@@ -126,7 +174,7 @@ class CharmHealthAPIClient:
             try:
                 response = await client.post(
                     self.token_url,
-                    params=params,
+                    data=form,
                     headers=headers,
                     timeout=self.timeout
                 )


### PR DESCRIPTION
### Summary
Intermittent “Failed to obtain new token with response: {response.text}” errors were caused by sending refresh parameters as query params with a JSON content type. This PR updates the refresh flow to use an OAuth2-compliant form-encoded request body, stabilizing token acquisition under bursty tool-call loads.

### Root cause
- `_refresh_token()` posted `params=...` with `Content-Type: application/json` to the OAuth token endpoint.
- OAuth2 token endpoints expect `application/x-www-form-urlencoded` in the request body.
- Under concurrency, responses sometimes lacked `access_token` (or returned non-JSON), triggering the “Failed to obtain new token” error.

### What changed
- In `src/api/api_client.py::_refresh_token()`:
  - Use `data=form` instead of `params=...`.
  - Set headers to `Content-Type: application/x-www-form-urlencoded` and `Accept: application/json`.
  - Keep existing shared token cache, lock, and 5-minute early refresh behavior unchanged.

### Technical details
- Required form fields sent: `refresh_token`, `client_id`, `client_secret`, `redirect_uri`, `grant_type=refresh_token`.
- Continues to:
  - Cache token per `client_id` in class-level `_shared_token_cache`.
  - Guard concurrent refreshes with `_shared_token_locks`.
  - Force refresh on 401 with limited retries.

### Risk and impact
- Low risk: only affects the token refresh call shape; aligns with OAuth2 spec and typical provider requirements.
- If provider previously tolerated query params, behavior is now stricter and correct. No external API surface changed.
