### PR TITLE
Keep MCP tokens in sync with mobile OAuth state

### DIFF
--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -1,4 +1,5 @@
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_http_headers
 from typing import Optional, List, Dict, Any, Literal, TypedDict
 from datetime import date
 from api import CharmHealthAPIClient
@@ -30,6 +31,8 @@ async def managePatientVitals(
     start_date: Optional[date] = None,
     end_date: Optional[date] = None,
     limit: Optional[int] = None,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient vitals and vital signs.
@@ -56,7 +59,43 @@ async def managePatientVitals(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientVitals using user credentials")
+        else:
+            logger.info("managePatientVitals using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "list":
@@ -242,6 +281,8 @@ async def managePatientDrugs(
     
     # Workflow fields
     check_allergies: Optional[bool] = True,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient drugs and supplements.
@@ -271,7 +312,43 @@ async def managePatientDrugs(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientDrugs using user credentials")
+        else:
+            logger.info("managePatientDrugs using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             # Safety check: Review allergies before prescribing
             if action == "add" and check_allergies:
@@ -488,6 +565,8 @@ async def managePatientAllergies(
     allergy_status: Optional[str] = None,
     allergy_date: Optional[date] = None,
     comments: Optional[str] = None,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient allergies.
@@ -511,7 +590,43 @@ async def managePatientAllergies(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientAllergies using user credentials")
+        else:
+            logger.info("managePatientAllergies using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "list":
@@ -621,6 +736,8 @@ async def managePatientDiagnoses(
     encounter_id: Optional[str] = None,
     diagnosis_order: Optional[int] = None,
     comments: Optional[str] = None,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient diagnoses.
@@ -644,7 +761,43 @@ async def managePatientDiagnoses(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientDiagnoses using user credentials")
+        else:
+            logger.info("managePatientDiagnoses using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "list":

--- a/src/tools/clinical_support.py
+++ b/src/tools/clinical_support.py
@@ -1,4 +1,5 @@
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_http_headers
 from typing import Optional, List, Dict, Any, Literal, TypedDict
 from datetime import date
 from api import CharmHealthAPIClient
@@ -17,6 +18,7 @@ async def managePatientNotes(
     patient_id: str,
     record_id: Optional[str] = None,
     notes: Optional[str] = None,
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient notes.
@@ -39,7 +41,43 @@ async def managePatientNotes(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientNotes using user credentials")
+        else:
+            logger.info("managePatientNotes using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "list":
@@ -117,6 +155,8 @@ async def managePatientRecalls(
     email_reminder_before: Optional[int] = None,
     send_text_reminder: Optional[bool] = None,
     text_reminder_before: Optional[int] = None,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient recalls.
@@ -140,7 +180,43 @@ async def managePatientRecalls(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientRecalls using user credentials")
+        else:
+            logger.info("managePatientRecalls using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "list":
@@ -248,6 +324,8 @@ async def managePatientFiles(
     email: Optional[str] = None,
     rep_first_name: Optional[str] = None,
     rep_last_name: Optional[str] = None,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient files and documents.
@@ -270,7 +348,43 @@ async def managePatientFiles(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientFiles using user credentials")
+        else:
+            logger.info("managePatientFiles using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "upload_photo":
@@ -386,6 +500,8 @@ async def managePatientLabs(
     
     # Adding lab results
     result_details: Optional[Dict[str, Any]] = None,
+    
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient laboratory results.
@@ -408,7 +524,43 @@ async def managePatientLabs(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"managePatientLabs using user credentials")
+        else:
+            logger.info("managePatientLabs using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "list":

--- a/src/tools/encounter_management.py
+++ b/src/tools/encounter_management.py
@@ -1,4 +1,5 @@
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_http_headers
 from typing import Optional, List, Dict, Any, Literal, TypedDict
 from datetime import date
 from api import CharmHealthAPIClient
@@ -23,7 +24,8 @@ async def manageEncounter(
     visit_type_id: Optional[str] = None,
     encounter_mode: Optional[Literal["In Person", "Phone Call", "Video Consult"]] = "In Person",
     chief_complaint: Optional[str] = None,
-    reason: Optional[str] = None  # Required for unlock action
+    reason: Optional[str] = None,  # Required for unlock action
+    ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage encounters.
@@ -67,7 +69,43 @@ async def manageEncounter(
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
     """
-    async with CharmHealthAPIClient() as client:
+    # Extract user tokens and environment from HTTP headers (proper FastMCP way)
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+        
+        # If accounts_server is provided, use it for token URL (mobile flow)
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+        
+        # Normalize base URL to include API path
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+        
+        if access_token:
+            logger.info(f"manageEncounter using user credentials")
+        else:
+            logger.info("manageEncounter using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+    
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
         try:
             match action:
                 case "review":
@@ -118,8 +156,7 @@ async def manageEncounter(
                     
                     # Get vitals for this encounter
                     try:
-                        vitals_response = await client.get("/vitals", params={
-                            "patient_id": patient_id,
+                        vitals_response = await client.get(f"/patients/{patient_id}/vitals", params={
                             "encounter_id": encounter_id
                         })
                         encounter_details["vitals"] = vitals_response.get("vitals", [])
@@ -128,8 +165,7 @@ async def manageEncounter(
                     
                     # Get diagnoses for this encounter
                     try:
-                        diagnoses_response = await client.get("/diagnoses", params={
-                            "patient_id": patient_id,
+                        diagnoses_response = await client.get(f"/patients/{patient_id}/diagnoses", params={
                             "encounter_id": encounter_id
                         })
                         encounter_details["diagnoses"] = diagnoses_response.get("diagnoses", [])
@@ -138,11 +174,10 @@ async def manageEncounter(
                     
                     # Get medications for this encounter
                     try:
-                        medications_response = await client.get("/drugs", params={
-                            "patient_id": patient_id,
+                        medications_response = await client.get(f"/patients/{patient_id}/medications", params={
                             "encounter_id": encounter_id
                         })
-                        encounter_details["medications"] = medications_response.get("drugs", [])
+                        encounter_details["medications"] = medications_response.get("medications", [])
                     except:
                         encounter_details["medications"] = []
                     


### PR DESCRIPTION
- Supprt for MCP client now reloading Charm Keychain inside every request modifier, so each call sends the latest access token, refresh token, client secret, and accounts-server URL issued by the OAuth flow.
- MCP server tools read those headers per request and pass them into client-side CharmHealth API Client, keeping refresh token exchanges aligned and preventing `invalid_client` errors after the first hour.
- Environment-based auth remains untouched; when no user headers are present the tools continue to use the existing `CHARMHEALTH_*` env vars.