### PR TITLE
[CH-381] MCP tool audit fixes — communication tools, reschedule, Tier 1 & 2 bugs

### DIFF
--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -231,6 +231,7 @@ class CharmHealthAPIClient:
                     pass
                 return await self._make_request(method, endpoint, params, data, retry_count + 1)
             logger.error(f"HTTP error {e.response.status_code}: {e}")
+            logger.error(f"Response body: {e.response.text}")
             return {"error": f"HTTP {e.response.status_code}: {e.response.text}"}
             
         except httpx.RequestError as e:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -30,6 +30,7 @@ mcp_composite_server.mount(server=encounter_management_mcp)
 mcp_composite_server.mount(server=clinical_data_mcp)
 mcp_composite_server.mount(server=clinical_support_mcp)
 mcp_composite_server.mount(server=task_management_mcp)
+mcp_composite_server.mount(server=communication_mcp)
 
 @mcp_composite_server.custom_route("/health", methods=["GET"])
 async def health_check(request: Request) -> JSONResponse:

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -42,6 +42,12 @@ from .task_management import (
     manageTasks
 )
 
+from .communication import (
+    communication_mcp,
+    manageMessages,
+    manageFax
+)
+
 __all__ = [
     "core_tools_mcp",
     "patient_management_mcp",
@@ -64,5 +70,8 @@ __all__ = [
     "managePatientFiles",
     "managePatientLabs",
     "task_management_mcp",
-    "manageTasks"
+    "manageTasks",
+    "communication_mcp",
+    "manageMessages",
+    "manageFax"
 ]

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -33,8 +33,10 @@ async def managePatientVitals(
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
     limit: Optional[int] = None,
-    
-    
+
+    # Date for add without encounter
+    entry_date: Optional[date] = None,
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """
@@ -47,17 +49,20 @@ async def managePatientVitals(
     
     <instructions>
     Actions:
-    - "add": Record new vitals (requires patient_id + encounter_id + vitals dict OR individual vital fields). Check available vitals with getPracticeInfo(info_type='vitals') first to ensure all vital names and units are correct.
+    - "add": Record new vitals (requires patient_id + vitals dict OR individual vital fields, plus encounter_id OR entry_date; defaults to today if neither provided). Check available vitals with getPracticeInfo(info_type='vitals') first to ensure all vital names and units are correct.
     - "list": Show patient vital history (optionally filter by vital name and/or date range)
     - "update": Modify existing vital record (requires record_id + fields to change)
     - "delete": Remove incorrect vital record (requires record_id)
     
-    Vitals Format: 
-    - As dict: {"Weight": "70 kg", "BP": "120/80 mmHg", "Pulse": "72 bpm", "Temperature": "98.6 F"}
-    - Individual: vital_name="Weight", vital_value="70", vital_unit="kg"
-    
-    Common Vitals: Weight, Height, Blood Pressure (BP), Pulse Rate, Temperature, Respiratory Rate, Oxygen Saturation
-    Use getPracticeInfo(info_type='vitals') to see available vital types and proper naming
+    Vitals Format:
+    - As dict: keys are EXACT CharmHealth vital names, values are "value unit" strings.
+      Example: {"Systolic BP": "120 mmHg", "Diastolic BP": "80 mmHg", "Weight": "150 lbs", "Temp": "98 F"}
+    - Individual: vital_name="Systolic BP", vital_value="120", vital_unit="mmHg"
+
+    IMPORTANT: vital_name must be the exact CharmHealth API name. NEVER include units inside the name.
+    Correct: "Systolic BP" | Wrong: "Systolic BP (mmHg)" or "Blood Pressure"
+    Known names: Weight, Height, BMI, Temp, Systolic BP, Diastolic BP, Pulse Rate, Pulse Pattern, Pulse Volume, Vision
+    Call getPracticeInfo(info_type='vitals') to get the full list of valid names and units for this practice.
 
     List filters:
     - vital_name_filter: e.g., vital_name_filter="Blood Pressure" (matches case-insensitively, substring ok)
@@ -190,14 +195,8 @@ async def managePatientVitals(
                     return strip_empty_values(response)
                     
                 case "add":
-                    if not encounter_id:
-                        return {
-                            "error": "encounter_id required for adding vitals",
-                            "guidance": "Vitals must be linked to an encounter. Use manageEncounter()() first to create an encounter, then record vitals."
-                        }
-                    
                     vitals_list = []
-                    
+
                     # Handle vitals dict format
                     if vitals:
                         for vital_name_key, vital_value_with_unit in vitals.items():
@@ -205,13 +204,13 @@ async def managePatientVitals(
                             parts = vital_value_with_unit.split()
                             value = parts[0] if parts else vital_value_with_unit
                             unit = " ".join(parts[1:]) if len(parts) > 1 else ""
-                            
+
                             vitals_list.append({
                                 "vital_name": vital_name_key,
                                 "vital_value": value,
                                 "vital_unit": unit
                             })
-                    
+
                     # Handle individual vital fields
                     elif vital_name and vital_value:
                         vitals_list.append({
@@ -224,26 +223,29 @@ async def managePatientVitals(
                             "error": "Either vitals dict or individual vital fields required",
                             "guidance": "Provide vitals as dict like {'Weight': '70 kg', 'BP': '120/80 mmHg'} OR individual fields (vital_name, vital_value, vital_unit)."
                         }
-                    
+
                     if not vitals_list:
                         return {
                             "error": "No valid vitals data provided",
                             "guidance": "Check your vitals format. Use getPracticeInfo(info_type='vitals') to see available vital types."
                         }
-                    
-                    vitals_data = [{
-                        "encounter_id": encounter_id,
-                        "vitals": vitals_list
-                    }]
-                    
-                    response = await client.post(f"/patients/{patient_id}/vitals", data=vitals_data)
-                    
-                    if response.get("vitals"):
-                        recorded_vitals = [v["vital_name"] for v in vitals_list]
-                        response["guidance"] = f"Vitals recorded successfully: {', '.join(recorded_vitals)}. These are now part of the patient's clinical record for encounter {encounter_id}."
+
+                    # Build the vitals entry — link to encounter if provided, otherwise use entry_date (defaulting to today)
+                    vitals_entry: Dict[str, Any] = {"vitals": vitals_list}
+                    if encounter_id:
+                        vitals_entry["encounter_id"] = encounter_id
                     else:
-                        response["guidance"] = "Vitals recording failed. Verify encounter_id exists and vital names match practice standards. Use getPracticeInfo(info_type='vitals') for valid vital types."
-                    
+                        vitals_entry["entry_date"] = (entry_date or date.today()).isoformat()
+
+                    response = await client.post(f"/patients/{patient_id}/vitals", data=[vitals_entry])
+
+                    if response.get("vital_entries"):
+                        recorded_vitals = [v["vital_name"] for v in vitals_list]
+                        context_label = f"encounter {encounter_id}" if encounter_id else "today's visit"
+                        response["guidance"] = f"Vitals recorded successfully: {', '.join(recorded_vitals)}. These are now part of the patient's clinical record for {context_label}."
+                    else:
+                        response["guidance"] = "Vitals recording failed. Verify vital names match practice standards. Use getPracticeInfo(info_type='vitals') for valid vital types."
+
                     return strip_empty_values(response)
                     
                 case "update":
@@ -300,7 +302,7 @@ async def managePatientVitals(
                     
                     response = await client.put(f"/patients/{patient_id}/vitals/{record_id}", data=update_data)
                     
-                    if response.get("vitals"):
+                    if response.get("vital_entries"):
                         updated_vitals = [v["vital_name"] for v in vitals_list]
                         response["guidance"] = f"Vital record {record_id} updated successfully: {', '.join(updated_vitals)}. The corrected vital signs are now in the patient's record."
                     else:
@@ -366,7 +368,7 @@ async def managePatientDrugs(
     <instructions>
     Actions:
     - "add": Prescribe new drug (requires drug_name, directions for medications; drug_name, dosage for supplements)
-    - "update": Modify existing prescription (requires record_id + fields to change)  
+    - "update": Modify existing prescription (requires record_id + fields to change). IMPORTANT: drug name and strength CANNOT be changed via update — use discontinue + add instead. Updatable fields: directions, dispense, refills, status.
     - "discontinue": Stop drug (requires record_id)
     - "list": Show all patient drugs by type (filter by substance_type, optionally filter by status)
     
@@ -597,22 +599,50 @@ async def managePatientDrugs(
                             "error": "record_id required for updates",
                             "guidance": "Use action='list' to find the medication/supplement record_id first."
                         }
-                    
+
                     if substance_type == "medication":
-                        update_data = {}
-                        if drug_name:
-                            update_data["drug_name"] = drug_name
+                        # GET current record to preserve required fields the API mandates on every PUT
+                        current_resp = await client.get(f"/patients/{patient_id}/medications")
+                        current_meds = current_resp.get("medications", [])
+                        current_med = next(
+                            (m for m in current_meds if str(m.get("patient_medication_id")) == str(record_id)),
+                            None,
+                        )
+                        if not current_med:
+                            return {
+                                "error": f"Medication record {record_id} not found",
+                                "guidance": "Use action='list' to verify the record_id exists for this patient."
+                            }
+
+                        if drug_name or strength:
+                            return {
+                                "error": "Drug name and strength cannot be changed via update — these are catalog fields set at prescribing time.",
+                                "guidance": "To change the drug or strength, use action='discontinue' on the current record, then action='add' to prescribe the new drug/strength."
+                            }
+
+                        # Build payload with all API-required fields, then overlay changes
+                        # NOTE: PUT /medications/{id} only accepts: is_active, directions, dispense, refills,
+                        # substitute_generic, manufacturing_type, and optional start_date/stop_date/dispense_unit/route/note_to_pharmacy
+                        update_data: Dict[str, Any] = {
+                            "is_active": current_med.get("is_active", True),
+                            "directions": current_med.get("directions", ""),
+                            "dispense": float(current_med.get("dispense") or 30),
+                            "refills": str(current_med.get("refills", "0")),
+                            "substitute_generic": current_med.get("substitute_generic", False),
+                            "manufacturing_type": current_med.get("manufacturing_type", "Manufactured"),
+                        }
+                        _enc_id = current_med.get("encounter_id")
+                        if _enc_id:
+                            update_data["encounter_id"] = int(_enc_id)
                         if directions:
                             update_data["directions"] = directions
                         if refills:
                             update_data["refills"] = refills
                         if status:
                             update_data["is_active"] = status == "active"
-                        if strength:
-                            update_data["strength_description"] = strength
-                        
+
                         response = await client.put(f"/patients/{patient_id}/medications/{record_id}", data=update_data)
-                        
+
                         if response.get("medications"):
                             response["guidance"] = f"Medication {record_id} updated successfully. Changes are now active in the patient's medication profile."
                     else:
@@ -642,13 +672,36 @@ async def managePatientDrugs(
                             "error": "record_id required to discontinue drug",
                             "guidance": "Use action='list' to find the medication/supplement record_id first."
                         }
-                    
+
                     if substance_type == "medication":
-                        # Set medication to inactive
-                        response = await client.put(f"/patients/{patient_id}/medications/{record_id}", data={"is_active": False})
-                        
+                        # GET current record to preserve required fields the API mandates on every PUT
+                        current_resp = await client.get(f"/patients/{patient_id}/medications")
+                        current_meds = current_resp.get("medications", [])
+                        current_med = next(
+                            (m for m in current_meds if str(m.get("patient_medication_id")) == str(record_id)),
+                            None,
+                        )
+                        if not current_med:
+                            return {
+                                "error": f"Medication record {record_id} not found",
+                                "guidance": "Use action='list' to verify the record_id exists for this patient."
+                            }
+
+                        discontinue_data: Dict[str, Any] = {
+                            "is_active": False,
+                            "directions": current_med.get("directions", ""),
+                            "dispense": float(current_med.get("dispense") or 30),
+                            "refills": str(current_med.get("refills", "0")),
+                            "substitute_generic": current_med.get("substitute_generic", False),
+                            "manufacturing_type": current_med.get("manufacturing_type", "Manufactured"),
+                        }
+                        _enc_id = current_med.get("encounter_id")
+                        if _enc_id:
+                            discontinue_data["encounter_id"] = int(_enc_id)
+                        response = await client.put(f"/patients/{patient_id}/medications/{record_id}", data=discontinue_data)
+
                         if response.get("medications"):
-                            response["guidance"] = f"Medication {record_id} discontinued. Patient should stop taking this medication. Document discontinuation reason in next encounter with manageEncounter()()."
+                            response["guidance"] = f"Medication {record_id} discontinued. Patient should stop taking this medication. Document discontinuation reason in next encounter with manageEncounter()."
                     else:
                         # Set supplement to inactive
                         response = await client.put(f"/patients/{patient_id}/supplements/{record_id}", data={"status": "Inactive"})
@@ -700,12 +753,14 @@ async def managePatientAllergies(
     Actions:
     - "add": Document new allergy (requires allergen, allergy_type, severity, reactions, allergy_date)
     - "list": Show all patient allergies (optionally filter by severity/type)
-    - "update": Modify existing allergy (requires record_id + fields to change)
+    - "update": Modify existing allergy (requires record_id, allergen, allergy_type, severity, allergy_status — use action='list' first to get current values, then pass all required fields with your changes)
     - "delete": Remove allergy record (requires record_id)
     
     Safety critical: Always check allergies before prescribing medications.
     Common allergens: "Penicillin", "Latex", "Shellfish", "Nuts", "Contrast dye"
-    Severity levels: "Mild", "Moderate", "Severe", "Life-threatening"
+    Severity levels: "Mild", "Moderate", "Severe"
+    Allergy types: "Medication", "Drug Substance", "Environmental", "Food", "Plant", "Animal", "Latex"
+    Status values: "Active", "Inactive"
 
     List filters:
     - severity_filter: e.g., severity_filter="Severe"
@@ -820,28 +875,30 @@ async def managePatientAllergies(
                     return strip_empty_values(response)
                     
                 case "update":
-                    if not record_id:
+                    missing = [k for k, v in {
+                        "record_id": record_id,
+                        "allergen": allergen,
+                        "allergy_type": allergy_type,
+                        "severity": severity,
+                        "allergy_status": allergy_status,
+                        "reactions": reactions,
+                        "allergy_date": allergy_date,
+                    }.items() if v is None or v == ""]
+                    if missing:
                         return {
-                            "error": "record_id required for updates",
-                            "guidance": "Use action='list' to find the allergy record_id first."
+                            "error": f"Missing required fields for update: {', '.join(missing)}",
+                            "guidance": "Use action='list' first to get current allergy values, then pass all required fields: record_id, allergen, allergy_type, severity, allergy_status, reactions (use empty string if none), allergy_date (observed_on from list)."
                         }
-                    
-                    update_data = {}
-                    if allergen:
-                        update_data["allergen"] = allergen
-                    if allergy_type:
-                        update_data["type"] = allergy_type
-                    if severity:
-                        update_data["severity"] = severity
-                    if reactions:
-                        update_data["reactions"] = reactions
-                    if allergy_status:
-                        update_data["status"] = allergy_status
-                    if allergy_date:
-                        update_data["date"] = allergy_date.isoformat()
-                    if comments:
-                        update_data["comments"] = comments
-                    
+
+                    update_data = {
+                        "allergen": allergen,
+                        "type": allergy_type,
+                        "severity": severity,
+                        "status": allergy_status,
+                        "reactions": reactions,
+                        "date": allergy_date.isoformat(),
+                    }
+
                     response = await client.put(f"/patients/{patient_id}/allergies/{record_id}", data=update_data)
                     if response.get("patient_allergy"):
                         response["guidance"] = f"Allergy record {record_id} updated successfully. Updated allergy information is now active in safety alerts."

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -881,13 +881,14 @@ async def managePatientAllergies(
                         "allergy_type": allergy_type,
                         "severity": severity,
                         "allergy_status": allergy_status,
-                        "reactions": reactions,
                         "allergy_date": allergy_date,
-                    }.items() if v is None or v == ""]
+                    }.items() if v is None or v == ""] + (
+                        ["reactions"] if reactions is None else []
+                    )
                     if missing:
                         return {
                             "error": f"Missing required fields for update: {', '.join(missing)}",
-                            "guidance": "Use action='list' first to get current allergy values, then pass all required fields: record_id, allergen, allergy_type, severity, allergy_status, reactions (use empty string if none), allergy_date (observed_on from list)."
+                            "guidance": "Use action='list' first to get current allergy values, then pass all required fields: record_id, allergen, allergy_type, severity, allergy_status, reactions (pass empty string if no reactions), allergy_date (observed_on from list)."
                         }
 
                     update_data = {

--- a/src/tools/clinical_support.py
+++ b/src/tools/clinical_support.py
@@ -209,10 +209,11 @@ async def managePatientRecalls(
     Actions:
     - "add": Schedule new recall (requires recall_type, notes, provider_id, facility_id)
     - "list": Show all patient recalls (optionally filter by type/date range)
-    - "update": Modify existing recall (requires record_id + fields to change)
+    - "update": Modify existing recall (requires record_id, recall_type, notes — use action='list' first to get current values, then pass all required fields with your changes)
     - "delete": Remove recall (requires record_id). Ask the user if they are sure they want to delete the recall before proceeding.
     
-    Common recall types: "Annual Physical", "Mammogram", "Colonoscopy", "Lab Follow-up", "Medication Review"
+    recall_type is a free-form string set by the practice (e.g. "Office Visit", "Follow-up", "Imaging", "Annual Physical"). Do not invent verbose names — use short descriptive terms.
+    Scheduling: PREFER recall_date (ISO date string, e.g. "2026-07-10"). If using recall_time/recall_timeunit instead, recall_period is also REQUIRED (e.g. recall_time=3, recall_timeunit="Months", recall_period="after") — omitting recall_period causes a server error.
     Reminder timing: email_reminder_before/text_reminder_before in days (e.g., 7 for one week)
     Use getPracticeInfo() to get valid provider_id and facility_id values
 
@@ -316,24 +317,34 @@ async def managePatientRecalls(
                             "error": "Missing required fields for recall",
                             "guidance": "For recalls, provide: recall_type, notes, provider_id, and facility_id. Use getPracticeInfo() to get valid provider and facility IDs."
                         }
-                    
-                    recall_data = [{
+
+                    # Build payload with only present fields — CharmHealth 500s on null values
+                    recall_entry: Dict[str, Any] = {
                         "recall_type": recall_type,
                         "notes": notes,
-                        "provider_id": provider_id,
-                        "facility_id": facility_id,
-                        "recall_date": recall_date.isoformat() if recall_date else None,
-                        "recall_time": recall_time,
-                        "recall_timeunit": recall_timeunit,
-                        "recall_period": recall_period,
-                        "encounter_id": encounter_id,
-                        "send_email_reminder": send_email_reminder,
-                        "email_reminder_before": str(email_reminder_before) if email_reminder_before else None,
-                        "send_text_reminder": send_text_reminder,
-                        "text_reminder_before": str(text_reminder_before) if text_reminder_before else None
-                    }]
-                    
-                    response = await client.post(f"/patients/{patient_id}/recalls", data=recall_data)
+                        "provider_id": int(provider_id),
+                        "facility_id": int(facility_id),
+                    }
+                    if recall_date:
+                        recall_entry["recall_date"] = recall_date.isoformat()
+                    if recall_time is not None:
+                        recall_entry["recall_time"] = recall_time
+                    if recall_timeunit:
+                        recall_entry["recall_timeunit"] = recall_timeunit
+                    if recall_period:
+                        recall_entry["recall_period"] = recall_period
+                    if encounter_id:
+                        recall_entry["encounter_id"] = int(encounter_id)
+                    if send_email_reminder is not None:
+                        recall_entry["send_email_reminder"] = send_email_reminder
+                    if email_reminder_before is not None:
+                        recall_entry["email_reminder_before"] = str(email_reminder_before)
+                    if send_text_reminder is not None:
+                        recall_entry["send_text_reminder"] = send_text_reminder
+                    if text_reminder_before is not None:
+                        recall_entry["text_reminder_before"] = str(text_reminder_before)
+
+                    response = await client.post(f"/patients/{patient_id}/recalls", data=[recall_entry])
                     if response.get("recalls"):
                         reminder_info = ""
                         if send_email_reminder or send_text_reminder:
@@ -342,24 +353,40 @@ async def managePatientRecalls(
                     return strip_empty_values(response)
                     
                 case "update":
-                    if not record_id:
+                    missing = [k for k, v in {
+                        "record_id": record_id,
+                        "recall_type": recall_type,
+                        "notes": notes,
+                    }.items() if not v]
+                    if missing:
                         return {
-                            "error": "record_id required for updates",
-                            "guidance": "Use action='list' to find the recall record_id first."
+                            "error": f"Missing required fields for update: {', '.join(missing)}",
+                            "guidance": "Use action='list' first to get current recall values (patient_recall_id, recall_type, notes), then pass all required fields with your changes."
                         }
-                    
-                    update_data = {}
-                    if recall_type:
-                        update_data["recall_type"] = recall_type
-                    if notes:
-                        update_data["notes"] = notes
+
+                    update_data: Dict[str, Any] = {
+                        "recall_type": recall_type,
+                        "notes": notes,
+                    }
                     if recall_date:
                         update_data["recall_date"] = recall_date.isoformat()
+                    if recall_time is not None:
+                        update_data["recall_time"] = recall_time
+                    if recall_timeunit:
+                        update_data["recall_timeunit"] = recall_timeunit
+                    if recall_period:
+                        update_data["recall_period"] = recall_period
+                    if provider_id:
+                        update_data["provider_id"] = int(provider_id)
                     if send_email_reminder is not None:
                         update_data["send_email_reminder"] = send_email_reminder
+                    if email_reminder_before is not None:
+                        update_data["email_reminder_before"] = str(email_reminder_before)
                     if send_text_reminder is not None:
                         update_data["send_text_reminder"] = send_text_reminder
-                    
+                    if text_reminder_before is not None:
+                        update_data["text_reminder_before"] = str(text_reminder_before)
+
                     response = await client.put(f"/patients/{patient_id}/recalls/{record_id}", data=update_data)
                     if response.get("recalls"):
                         response["guidance"] = f"Recall {record_id} updated successfully. Updated reminder settings are now active."
@@ -561,7 +588,7 @@ async def managePatientFiles(
 @clinical_support_mcp.tool
 @with_tool_metrics()
 async def managePatientLabs(
-    action: Literal["list", "get_details", "add_result"],
+    action: Literal["list", "get_details"],
     # Common fields
     patient_id: Optional[str] = None,
     group_id: Optional[str] = None,
@@ -579,27 +606,21 @@ async def managePatientLabs(
     sort_by: Optional[Literal["DATE", "FULL_NAME"]] = None,
     is_ascending: Optional[bool] = None,
     
-    # Adding lab results
-    result_details: Optional[Dict[str, Any]] = None,
-    
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """
     Manage patient laboratory results.
     
     <usecase>
-    Complete laboratory results management - list lab results, get detailed reports, 
-    and add new lab results. Handles the full lab workflow for clinical decision-making.
+    Laboratory results management - list lab results and get detailed reports.
+    Lab results arrive automatically from integrated labs (LabCorp, Quest). For manual entry, use the CharmHealth web portal.
     </usecase>
     
     <instructions>
     Actions:
     - "list": Show lab results with filtering (optionally filter by patient_id, reviewer_id, status, date range)
     - "get_details": Get detailed lab report (requires group_id OR lab_order_id)
-    - "add_result": Add new lab results (requires patient_id + result_details)
-    
     For detailed results: Use group_id for result groups or lab_order_id for specific orders
-    For adding results: Provide structured result_details with tests, parameters, and values
     Status codes: 0 for pending, 2 for final results
 
     List filters (in addition to API parameters):
@@ -725,27 +746,6 @@ async def managePatientLabs(
                         response["guidance"] = "Detailed lab results retrieved successfully. Review the test parameters and values for clinical interpretation."
                     else:
                         response["guidance"] = "Lab details not found. Verify the group_id or lab_order_id is correct using action='list' first."
-                    
-                    return strip_empty_values(response)
-                    
-                case "add_result":
-                    if not patient_id or not result_details:
-                        return {
-                            "error": "patient_id and result_details required",
-                            "guidance": "Provide patient_id and structured result_details containing lab test information, parameters, and values."
-                        }
-                    
-                    add_data = {
-                        "patient_id": patient_id,
-                        "result_details": result_details
-                    }
-                    
-                    response = await client.post("/labs/results/upload", data=add_data)
-                    
-                    if response.get("code") == "0":
-                        response["guidance"] = "Lab results added successfully. Results are now available in the patient's lab history and can be used for clinical decision-making."
-                    else:
-                        response["guidance"] = "Lab result upload failed. Verify the result_details structure includes required fields (tests, parameters, values) and patient_id is valid."
                     
                     return strip_empty_values(response)
                     

--- a/src/tools/communication.py
+++ b/src/tools/communication.py
@@ -141,7 +141,7 @@ async def manageMessages(
                         case "secure":
                             return await _send_secure_message(
                                 client, patient_id, content, subject,
-                                recipient_member_ids,
+                                recipient_member_ids, facility_id,
                             )
                         case _:
                             return {
@@ -273,6 +273,7 @@ async def _send_secure_message(
     content: str,
     subject: Optional[str],
     recipient_member_ids: Optional[str],
+    facility_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Send secure portal message."""
     data: Dict[str, Any] = {
@@ -281,6 +282,8 @@ async def _send_secure_message(
         "patients": patient_id,
     }
 
+    if facility_id:
+        data["facility_id"] = int(facility_id)
     if recipient_member_ids:
         data["members"] = recipient_member_ids
 

--- a/src/tools/communication.py
+++ b/src/tools/communication.py
@@ -1,0 +1,519 @@
+from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_http_headers
+from typing import Optional, List, Dict, Any, Literal
+from api import CharmHealthAPIClient
+from common.utils import strip_empty_values
+import logging
+from telemetry import with_tool_metrics
+
+logger = logging.getLogger(__name__)
+
+communication_mcp = FastMCP(name="CharmHealth Communication MCP Server")
+
+
+def _get_client_params() -> Dict[str, Any]:
+    """Extract HTTP headers for API client initialization."""
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    client_secret = None
+
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+
+        if access_token:
+            logger.info("Communication tool using user credentials")
+        else:
+            logger.info("Communication tool using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "base_url": base_url,
+        "token_url": token_url,
+        "client_secret": client_secret,
+    }
+
+
+@communication_mcp.tool
+@with_tool_metrics()
+async def manageMessages(
+    action: Literal["send", "list", "get_thread"],
+
+    # Common
+    patient_id: Optional[str] = None,
+    facility_id: Optional[str] = None,
+
+    # Send fields
+    content: Optional[str] = None,
+    channel: Optional[Literal["sms", "whatsapp", "secure", "auto"]] = "auto",
+    subject: Optional[str] = None,  # For secure messages
+    recipient_member_ids: Optional[str] = None,  # Comma-separated, for secure messages to providers
+    template_name: Optional[str] = None,  # For WhatsApp templated messages
+    template_header_placeholders: Optional[List[str]] = None,
+    template_body_placeholders: Optional[List[str]] = None,
+
+    # List fields
+    message_type: Optional[Literal["incoming", "outgoing", "all"]] = "all",
+    section: Optional[Literal["FROM_PATIENTS", "TO_PATIENTS", "ALL"]] = "ALL",
+    page: Optional[int] = 1,
+    page_size: Optional[int] = 20,
+
+    # Get thread fields
+    thread_channel: Optional[Literal["sms", "whatsapp", "secure", "all"]] = "all",
+
+    ctx: Context = None,
+) -> Dict[str, Any]:
+    """
+    Manage patient and provider messaging across SMS, WhatsApp, and secure messaging channels.
+
+    <usecase>
+    Send messages to patients, read inbox messages, and retrieve conversation threads.
+    Supports SMS (Twilio/Telnyx), WhatsApp Business, and secure portal messaging.
+    Use this for patient communication, follow-ups, appointment confirmations, and
+    responding to patient inquiries.
+    </usecase>
+
+    <instructions>
+    Actions:
+    - "send": Send a message to a patient (requires patient_id and content).
+      Channel options:
+        - "sms": Send via text message (patient must have TEXT_NOTIFY_ENABLED)
+        - "whatsapp": Send via WhatsApp (patient must be opted in)
+        - "secure": Send via secure portal message (requires subject)
+        - "auto": Automatically select best available channel (default)
+      For WhatsApp templates, provide template_name and placeholder values.
+      For secure messages to providers, use recipient_member_ids.
+
+    - "list": Show recent messages from inbox.
+      Filter by section: "FROM_PATIENTS", "TO_PATIENTS", or "ALL".
+      For SMS messages, filter by message_type: "incoming", "outgoing", or "all".
+      Use facility_id to filter by facility.
+
+    - "get_thread": Get full conversation history with a specific patient (requires patient_id).
+      Filter by thread_channel to see only SMS, WhatsApp, secure, or all channels.
+
+    Before sending clinical content, confirm with the provider. Routine messages
+    (appointment reminders, general notifications) can be sent directly.
+    </instructions>
+    """
+    client_params = _get_client_params()
+
+    async with CharmHealthAPIClient(**client_params) as client:
+        try:
+            match action:
+                case "send":
+                    if not patient_id or not content:
+                        return {
+                            "error": "Missing required fields",
+                            "guidance": "For sending, provide: patient_id and content. Optionally specify channel (sms/whatsapp/secure/auto)."
+                        }
+
+                    resolved_channel = channel or "auto"
+
+                    if resolved_channel == "auto":
+                        resolved_channel = await _resolve_channel(client, patient_id)
+
+                    match resolved_channel:
+                        case "sms":
+                            return await _send_sms(client, patient_id, content, facility_id)
+                        case "whatsapp":
+                            return await _send_whatsapp(
+                                client, patient_id, content, facility_id,
+                                template_name, template_header_placeholders,
+                                template_body_placeholders,
+                            )
+                        case "secure":
+                            return await _send_secure_message(
+                                client, patient_id, content, subject,
+                                recipient_member_ids,
+                            )
+                        case _:
+                            return {
+                                "error": f"Unknown channel: {resolved_channel}",
+                                "guidance": "Use channel: sms, whatsapp, secure, or auto."
+                            }
+
+                case "list":
+                    return await _list_messages(
+                        client, section, message_type, facility_id,
+                        page, page_size,
+                    )
+
+                case "get_thread":
+                    if not patient_id:
+                        return {
+                            "error": "patient_id required for get_thread",
+                            "guidance": "Provide patient_id to retrieve their conversation history."
+                        }
+                    return await _get_thread(
+                        client, patient_id, thread_channel, page, page_size,
+                    )
+
+        except Exception as e:
+            logger.error(f"Error in manageMessages: {e}")
+            return {
+                "error": str(e),
+                "guidance": f"Message {action} failed. Check parameters and try again."
+            }
+
+
+async def _resolve_channel(client: CharmHealthAPIClient, patient_id: str) -> str:
+    """Determine the best channel for a patient based on their preferences."""
+    try:
+        response = await client.get(f"/patients/{patient_id}/contactdetails")
+        contact = response if isinstance(response, dict) else {}
+
+        text_enabled = contact.get("text_notify_enabled", False)
+        if isinstance(text_enabled, str):
+            text_enabled = text_enabled.lower() == "true"
+
+        whatsapp_enabled = contact.get("whatsapp_opted_in", False)
+        if isinstance(whatsapp_enabled, str):
+            whatsapp_enabled = whatsapp_enabled.lower() == "true"
+
+        if whatsapp_enabled:
+            return "whatsapp"
+        if text_enabled:
+            return "sms"
+        return "secure"
+    except Exception:
+        return "secure"
+
+
+async def _send_sms(
+    client: CharmHealthAPIClient,
+    patient_id: str,
+    content: str,
+    facility_id: Optional[str],
+) -> Dict[str, Any]:
+    """Send SMS to a patient."""
+    data: Dict[str, Any] = {"content": content}
+    if facility_id:
+        data["facility_id"] = int(facility_id)
+
+    response = await client.post(
+        f"/textmessages/patient/{patient_id}/outgoing",
+        data=data,
+    )
+
+    if response.get("error"):
+        error_msg = str(response["error"]).lower()
+        if "disabled" in error_msg or "preference" in error_msg:
+            response["guidance"] = "Patient has text notifications disabled. Try channel='secure' for portal messaging."
+        elif "10dlc" in error_msg or "registration" in error_msg:
+            response["guidance"] = "Practice needs 10DLC registration for SMS. Try channel='secure' instead."
+        else:
+            response["guidance"] = "SMS send failed. Try channel='secure' as an alternative."
+    else:
+        response["channel_used"] = "sms"
+        response["guidance"] = "SMS sent successfully."
+
+    return strip_empty_values(response)
+
+
+async def _send_whatsapp(
+    client: CharmHealthAPIClient,
+    patient_id: str,
+    content: str,
+    facility_id: Optional[str],
+    template_name: Optional[str],
+    header_placeholders: Optional[List[str]],
+    body_placeholders: Optional[List[str]],
+) -> Dict[str, Any]:
+    """Send WhatsApp message to a patient."""
+    data: Dict[str, Any] = {}
+
+    if template_name:
+        data["template_name"] = template_name
+        template_content: Dict[str, Any] = {}
+        if header_placeholders:
+            template_content["HEADER_PLACEHOLDERS"] = header_placeholders
+        if body_placeholders:
+            template_content["BODY_PLACEHOLDERS"] = body_placeholders
+        data["content"] = template_content
+    else:
+        data["freeform_content"] = content
+
+    if facility_id:
+        data["facility_id"] = int(facility_id)
+
+    response = await client.post(
+        f"/messages/whatsapp/patient/{patient_id}/send",
+        data=data,
+    )
+
+    if response.get("error"):
+        response["guidance"] = "WhatsApp send failed. Patient may not be opted in. Try channel='sms' or channel='secure'."
+    else:
+        response["channel_used"] = "whatsapp"
+        response["guidance"] = "WhatsApp message sent successfully."
+
+    return strip_empty_values(response)
+
+
+async def _send_secure_message(
+    client: CharmHealthAPIClient,
+    patient_id: str,
+    content: str,
+    subject: Optional[str],
+    recipient_member_ids: Optional[str],
+) -> Dict[str, Any]:
+    """Send secure portal message."""
+    data: Dict[str, Any] = {
+        "content": content,
+        "subject": subject or "Message from your care team",
+        "patients": patient_id,
+    }
+
+    if recipient_member_ids:
+        data["members"] = recipient_member_ids
+
+    response = await client.post("/messages", data=data)
+
+    if response.get("error"):
+        response["guidance"] = "Secure message send failed. Verify patient has portal access."
+    else:
+        response["channel_used"] = "secure"
+        response["guidance"] = "Secure message sent successfully. Patient will see it in their portal."
+
+    return strip_empty_values(response)
+
+
+async def _list_messages(
+    client: CharmHealthAPIClient,
+    section: Optional[str],
+    message_type: Optional[str],
+    facility_id: Optional[str],
+    page: Optional[int],
+    page_size: Optional[int],
+) -> Dict[str, Any]:
+    """List messages from inbox."""
+    results: Dict[str, Any] = {"messages": []}
+
+    # Fetch SMS messages
+    sms_params: Dict[str, Any] = {"page": page or 1}
+    if message_type and message_type != "all":
+        sms_params["type"] = message_type.upper()
+    else:
+        sms_params["type"] = "BOTH"
+    if facility_id:
+        sms_params["facilityIds"] = facility_id
+
+    sms_response = await client.get("/textmessages", params=sms_params)
+    sms_messages = sms_response.get("messages", [])
+    for msg in sms_messages:
+        msg["channel"] = "sms"
+    results["messages"].extend(sms_messages)
+
+    # Fetch secure messages
+    secure_params: Dict[str, Any] = {
+        "startIndex": ((page or 1) - 1) * (page_size or 20) + 1,
+        "noOfRecords": page_size or 20,
+    }
+    if section and section != "ALL":
+        secure_params["section"] = section
+
+    secure_response = await client.get("/messages", params=secure_params)
+    secure_messages = secure_response.get("messages", [])
+    for msg in secure_messages:
+        msg["channel"] = "secure"
+    results["messages"].extend(secure_messages)
+
+    results["total_count"] = len(results["messages"])
+    results["page"] = page or 1
+
+    if results["messages"]:
+        results["guidance"] = f"Found {results['total_count']} messages. Use action='get_thread' with a patient_id to see the full conversation."
+    else:
+        results["guidance"] = "No messages found matching the criteria."
+
+    return strip_empty_values(results)
+
+
+async def _get_thread(
+    client: CharmHealthAPIClient,
+    patient_id: str,
+    channel: Optional[str],
+    page: Optional[int],
+    page_size: Optional[int],
+) -> Dict[str, Any]:
+    """Get full conversation thread with a patient."""
+    results: Dict[str, Any] = {"messages": [], "patient_id": patient_id}
+
+    include_sms = channel in ("sms", "all", None)
+    include_whatsapp = channel in ("whatsapp", "all", None)
+    include_secure = channel in ("secure", "all", None)
+
+    if include_sms:
+        sms_response = await client.get(
+            f"/textmessages",
+            params={"patient_id": patient_id, "type": "BOTH", "page": page or 1},
+        )
+        for msg in sms_response.get("messages", []):
+            msg["channel"] = "sms"
+            results["messages"].append(msg)
+
+    if include_whatsapp:
+        wa_response = await client.get(
+            "/messages/whatsapp/fetch_patient_records",
+            params={"patient_id": patient_id},
+        )
+        for msg in wa_response.get("messages", wa_response.get("records", [])):
+            msg["channel"] = "whatsapp"
+            results["messages"].append(msg)
+
+    if include_secure:
+        secure_response = await client.get(
+            f"/messages/patient/{patient_id}",
+            params={
+                "startIndex": ((page or 1) - 1) * (page_size or 20) + 1,
+                "noOfRecords": page_size or 20,
+            },
+        )
+        for msg in secure_response.get("messages", []):
+            msg["channel"] = "secure"
+            results["messages"].append(msg)
+
+    results["total_count"] = len(results["messages"])
+
+    if results["messages"]:
+        results["guidance"] = f"Found {results['total_count']} messages with this patient. Use action='send' to respond."
+    else:
+        results["guidance"] = "No message history found with this patient."
+
+    return strip_empty_values(results)
+
+
+@communication_mcp.tool
+@with_tool_metrics()
+async def manageFax(
+    action: Literal["send", "status"],
+
+    # Send fields
+    recipient_fax_number: Optional[str] = None,
+    recipient_name: Optional[str] = None,
+    document_content_base64: Optional[str] = None,
+    subject: Optional[str] = None,
+    remarks: Optional[str] = None,
+    facility_id: Optional[str] = None,
+    reference: Optional[str] = None,
+
+    # Status fields
+    fax_id: Optional[str] = None,
+
+    ctx: Context = None,
+) -> Dict[str, Any]:
+    """
+    Send faxes and check fax delivery status.
+
+    <usecase>
+    Fax clinical documents (referrals, records, prior auth forms) to providers,
+    facilities, pharmacies, and insurance companies. Check delivery status of sent faxes.
+    </usecase>
+
+    <instructions>
+    Actions:
+    - "send": Fax a document (requires recipient_fax_number, recipient_name, document_content_base64).
+      document_content_base64 must be a base64-encoded PDF.
+      Optionally include subject, remarks, and reference for the cover page.
+      facility_id determines which facility's fax credentials and return number are used.
+
+    - "status": Check fax delivery status (requires fax_id).
+      Status values: QUEUED, SENT, FAILED, YET_TO_SEND.
+
+    Common fax use cases:
+    - Referral letters to specialists
+    - Medical records requests
+    - Prior authorization forms to insurance
+    - Prescription orders to pharmacies without e-prescribe
+    </instructions>
+    """
+    client_params = _get_client_params()
+
+    async with CharmHealthAPIClient(**client_params) as client:
+        try:
+            match action:
+                case "send":
+                    if not recipient_fax_number or not recipient_name or not document_content_base64:
+                        return {
+                            "error": "Missing required fields",
+                            "guidance": "For sending a fax, provide: recipient_fax_number, recipient_name, and document_content_base64 (base64-encoded PDF)."
+                        }
+
+                    fax_data: Dict[str, Any] = {
+                        "to_number": recipient_fax_number,
+                        "recipient_name": recipient_name,
+                        "document_content": document_content_base64,
+                        "document_type": "PDF",
+                    }
+
+                    if subject:
+                        fax_data["subject"] = subject
+                    if remarks:
+                        fax_data["remarks"] = remarks
+                    if facility_id:
+                        fax_data["facility_id"] = int(facility_id)
+                    if reference:
+                        fax_data["reference"] = reference
+
+                    response = await client.post("/fax/send", data=fax_data)
+
+                    if response.get("error"):
+                        error_msg = str(response["error"]).lower()
+                        if "not enabled" in error_msg or "disabled" in error_msg:
+                            response["guidance"] = "Fax is not enabled for this facility. Check fax configuration."
+                        else:
+                            response["guidance"] = "Fax send failed. Verify the fax number format and facility configuration."
+                    else:
+                        fax_detail_id = response.get("FAXDETAILS_ID") or response.get("fax_id")
+                        response["guidance"] = f"Fax queued for delivery (ID: {fax_detail_id}). Use action='status' to check delivery."
+
+                    return strip_empty_values(response)
+
+                case "status":
+                    if not fax_id:
+                        return {
+                            "error": "fax_id required for status check",
+                            "guidance": "Provide the fax_id returned from a previous send action."
+                        }
+
+                    response = await client.get(f"/fax/{fax_id}/status")
+
+                    status = response.get("status", response.get("fax_status", "UNKNOWN"))
+                    response["fax_id"] = fax_id
+                    response["status"] = status
+
+                    match status:
+                        case "SENT":
+                            response["guidance"] = "Fax delivered successfully."
+                        case "QUEUED" | "YET_TO_SEND":
+                            response["guidance"] = "Fax is still in the queue. Check again shortly."
+                        case "FAILED":
+                            response["guidance"] = "Fax delivery failed. Verify the fax number and try resending."
+                        case _:
+                            response["guidance"] = f"Fax status: {status}."
+
+                    return strip_empty_values(response)
+
+        except Exception as e:
+            logger.error(f"Error in manageFax: {e}")
+            return {
+                "error": str(e),
+                "guidance": f"Fax {action} failed. Check parameters and try again."
+            }

--- a/src/tools/communication.py
+++ b/src/tools/communication.py
@@ -153,7 +153,7 @@ async def manageMessages(
 
                 case "list":
                     return await _list_messages(
-                        client, section, message_type, facility_id,
+                        client, section, facility_id,
                         page, page_size,
                     )
 
@@ -247,7 +247,13 @@ async def _send_whatsapp(
     body_placeholders: Optional[List[str]],
 ) -> Dict[str, Any]:
     """Send WhatsApp message to a patient."""
-    data: Dict[str, Any] = {}
+    if not facility_id:
+        return {
+            "error": "facility_id is required to send a WhatsApp message",
+            "guidance": "Provide facility_id. Use getPracticeInfo() to look up facility IDs."
+        }
+
+    data: Dict[str, Any] = {"facility_id": int(facility_id)}
 
     if template_name:
         data["template_name"] = template_name
@@ -259,9 +265,6 @@ async def _send_whatsapp(
         data["content"] = template_content
     else:
         data["freeform_content"] = content
-
-    if facility_id:
-        data["facility_id"] = int(facility_id)
 
     response = await client.post(
         f"/messages/whatsapp/patient/{patient_id}/send",
@@ -321,7 +324,6 @@ async def _send_secure_message(
 async def _list_messages(
     client: CharmHealthAPIClient,
     section: Optional[str],
-    message_type: Optional[str],
     facility_id: Optional[str],
     page: Optional[int],
     page_size: Optional[int],

--- a/src/tools/communication.py
+++ b/src/tools/communication.py
@@ -91,19 +91,21 @@ async def manageMessages(
 
     <instructions>
     Actions:
-    - "send": Send a message to a patient (requires patient_id and content).
+    - "send": Send a message to a patient (requires patient_id, content, and facility_id).
       Channel options:
         - "sms": Send via text message (patient must have TEXT_NOTIFY_ENABLED)
         - "whatsapp": Send via WhatsApp (patient must be opted in)
         - "secure": Send via secure portal message (requires subject)
         - "auto": Automatically select best available channel (default)
+      facility_id is required for all channels. Use getPracticeInfo() to look up facility IDs.
       For WhatsApp templates, provide template_name and placeholder values.
       For secure messages to providers, use recipient_member_ids.
 
-    - "list": Show recent messages from inbox.
-      Filter by section: "FROM_PATIENTS", "TO_PATIENTS", or "ALL".
-      For SMS messages, filter by message_type: "incoming", "outgoing", or "all".
+    - "list": Show recent secure portal messages from inbox.
+      Filter by section: "FROM_PATIENTS" (inbox) or "TO_PATIENTS" (sent).
       Use facility_id to filter by facility.
+      Note: SMS and WhatsApp conversations are not available via list — use action='get_thread'
+      with a patient_id to retrieve those.
 
     - "get_thread": Get full conversation history with a specific patient (requires patient_id).
       Filter by thread_channel to see only SMS, WhatsApp, secure, or all channels.
@@ -203,9 +205,17 @@ async def _send_sms(
     facility_id: Optional[str],
 ) -> Dict[str, Any]:
     """Send SMS to a patient."""
-    data: Dict[str, Any] = {"content": content}
-    if facility_id:
-        data["facility_id"] = int(facility_id)
+    if not facility_id:
+        return {
+            "error": "facility_id is required to send SMS",
+            "guidance": "Provide facility_id. Use getPracticeInfo() to look up facility IDs."
+        }
+
+    data: Dict[str, Any] = {
+        "content": content,
+        "type": "plain_text",
+        "facility_id": int(facility_id),
+    }
 
     response = await client.post(
         f"/textmessages/patient/{patient_id}/outgoing",
@@ -276,21 +286,31 @@ async def _send_secure_message(
     facility_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Send secure portal message."""
+    if not facility_id:
+        return {
+            "error": "facility_id is required to send a secure message",
+            "guidance": "Provide facility_id. Use getPracticeInfo() to look up facility IDs."
+        }
+
+    receivers: Dict[str, Any] = {
+        "patients": [{"patient_id": int(patient_id)}]
+    }
+    if recipient_member_ids:
+        member_ids = [mid.strip() for mid in recipient_member_ids.split(",") if mid.strip()]
+        receivers["members"] = [{"member_id": int(mid)} for mid in member_ids]
+
     data: Dict[str, Any] = {
         "content": content,
         "subject": subject or "Message from your care team",
-        "patients": patient_id,
+        "related_patient_id": int(patient_id),
+        "facility_id": int(facility_id),
+        "receivers": receivers,
     }
-
-    if facility_id:
-        data["facility_id"] = int(facility_id)
-    if recipient_member_ids:
-        data["members"] = recipient_member_ids
 
     response = await client.post("/messages", data=data)
 
     if response.get("error"):
-        response["guidance"] = "Secure message send failed. Verify patient has portal access."
+        response["guidance"] = "Secure message send failed. Verify patient has portal access and facility_id is correct."
     else:
         response["channel_used"] = "secure"
         response["guidance"] = "Secure message sent successfully. Patient will see it in their portal."
@@ -306,31 +326,23 @@ async def _list_messages(
     page: Optional[int],
     page_size: Optional[int],
 ) -> Dict[str, Any]:
-    """List messages from inbox."""
+    """List secure portal messages from inbox. SMS messages require a patient_id — use action='get_thread' instead."""
     results: Dict[str, Any] = {"messages": []}
 
-    # Fetch SMS messages
-    sms_params: Dict[str, Any] = {"page": page or 1}
-    if message_type and message_type != "all":
-        sms_params["type"] = message_type.upper()
-    else:
-        sms_params["type"] = "BOTH"
-    if facility_id:
-        sms_params["facilityIds"] = facility_id
+    # Secure messages inbox — section is required by the API
+    resolved_section = "inbox"
+    if section == "FROM_PATIENTS":
+        resolved_section = "inbox"
+    elif section == "TO_PATIENTS":
+        resolved_section = "sent"
 
-    sms_response = await client.get("/textmessages", params=sms_params)
-    sms_messages = sms_response.get("messages", [])
-    for msg in sms_messages:
-        msg["channel"] = "sms"
-    results["messages"].extend(sms_messages)
-
-    # Fetch secure messages
     secure_params: Dict[str, Any] = {
-        "startIndex": ((page or 1) - 1) * (page_size or 20) + 1,
-        "noOfRecords": page_size or 20,
+        "section": resolved_section,
+        "page": page or 1,
+        "per_page": page_size or 20,
     }
-    if section and section != "ALL":
-        secure_params["section"] = section
+    if facility_id:
+        secure_params["facility_id"] = int(facility_id)
 
     secure_response = await client.get("/messages", params=secure_params)
     secure_messages = secure_response.get("messages", [])
@@ -342,9 +354,9 @@ async def _list_messages(
     results["page"] = page or 1
 
     if results["messages"]:
-        results["guidance"] = f"Found {results['total_count']} messages. Use action='get_thread' with a patient_id to see the full conversation."
+        results["guidance"] = f"Found {results['total_count']} secure messages. Use action='get_thread' with a patient_id to see SMS/WhatsApp conversations."
     else:
-        results["guidance"] = "No messages found matching the criteria."
+        results["guidance"] = "No messages found. Use action='get_thread' with a patient_id to check SMS conversations."
 
     return strip_empty_values(results)
 

--- a/src/tools/encounter_management.py
+++ b/src/tools/encounter_management.py
@@ -15,7 +15,7 @@ encounter_management_mcp = FastMCP(name="CharmHealth Encounter Management MCP Se
 @with_tool_metrics()
 async def manageEncounter(
     patient_id: str,
-    action: Literal["create", "review", "sign", "unlock", "update"] = "create",
+    action: Literal["create", "review", "sign", "unlock", "update", "list"] = "create",
     provider_id: Optional[str] = None,
     facility_id: Optional[str] = None,
     encounter_date: Optional[date] = None,
@@ -27,6 +27,14 @@ async def manageEncounter(
     reason: Optional[str] = None,  # Required for unlock action
     template_ids: Optional[str] = None,  # comma-separated template IDs to attach (update action)
     entries: Optional[str] = None,  # JSON array: [{"entry_id": "...", "answer": "..."}] (update action)
+
+    # List action fields
+    filter_by: Optional[Literal["Status.Signed", "Status.Unsigned", "Status.All"]] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    per_page: Optional[int] = None,
+    page: Optional[int] = None,
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """
@@ -39,6 +47,7 @@ async def manageEncounter(
     
     <instructions>
     Actions:
+    - "list": List encounters for a patient (requires patient_id; optionally filter by filter_by, start_date, end_date, per_page, page)
     - "create": Create new encounter and document clinical findings (default)
     - "review": Display complete encounter details for review before signing
     - "sign": Electronically sign encounter after review and confirmation
@@ -118,6 +127,35 @@ async def manageEncounter(
     ) as client:
         try:
             match action:
+                case "list":
+                    params: Dict[str, Any] = {"patient_id": int(patient_id)}
+                    if filter_by:
+                        params["filter_by"] = filter_by
+                    if facility_id:
+                        params["facility_id"] = int(facility_id)
+                    if provider_id:
+                        params["member_id"] = int(provider_id)
+                    if start_date:
+                        params["start_date"] = start_date.isoformat()
+                    if end_date:
+                        params["end_date"] = end_date.isoformat()
+                    if per_page:
+                        params["per_page"] = per_page
+                    if page:
+                        params["page"] = page
+
+                    response = await client.get("/encounters", params=params)
+                    encounters = response.get("encounters") or []
+                    response["total_count"] = len(encounters)
+                    if encounters:
+                        response["guidance"] = (
+                            f"Found {len(encounters)} encounters for this patient."
+                            " Use action='review' with an encounter_id to see full details."
+                        )
+                    else:
+                        response["guidance"] = "No encounters found matching the filters."
+                    return strip_empty_values(response)
+
                 case "review":
                     if not encounter_id:
                         return {

--- a/src/tools/encounter_management.py
+++ b/src/tools/encounter_management.py
@@ -218,6 +218,39 @@ async def manageEncounter(
                         logger.error(f"Error fetching medications: {e}")
                         encounter_details["medications"] = []
                     
+                    # Get supplements for this encounter
+                    try:
+                        supps_response = await client.get(f"/patients/{patient_id}/supplements")
+                        all_supps = supps_response.get("supplements", []) or []
+                        encounter_supps = [
+                            s for s in all_supps
+                            if str(s.get("encounter_id")) == str(encounter_id) and s.get("encounter_id")
+                        ]
+                        if not encounter_supps and encounter_details["encounter_info"]["encounter_date"]:
+                            encounter_date_str = encounter_details["encounter_info"]["encounter_date"].split()[0] if encounter_details["encounter_info"]["encounter_date"] else None
+                            if encounter_date_str:
+                                encounter_supps = [
+                                    s for s in all_supps
+                                    if s.get("start_date") == encounter_date_str
+                                ]
+                        encounter_details["supplements"] = encounter_supps
+                    except Exception as e:
+                        logger.error(f"Error fetching supplements: {e}")
+                        encounter_details["supplements"] = []
+
+                    # Get lab orders for this encounter
+                    try:
+                        labs_response = await client.get(f"/patients/{patient_id}/lab-orders")
+                        all_labs = labs_response.get("lab_orders", []) or []
+                        encounter_labs = [
+                            l for l in all_labs
+                            if str(l.get("encounter_id")) == str(encounter_id) and l.get("encounter_id")
+                        ]
+                        encounter_details["lab_orders"] = encounter_labs
+                    except Exception as e:
+                        logger.error(f"Error fetching lab orders: {e}")
+                        encounter_details["lab_orders"] = []
+
                     # Get clinical notes
                     clinical_notes = found_encounter.get("chief_complaints")
                     if clinical_notes:
@@ -231,6 +264,10 @@ async def manageEncounter(
                         summary_items.append(f"✓ {len(encounter_details['diagnoses'])} diagnosis/diagnoses documented")
                     if encounter_details["medications"]:
                         summary_items.append(f"✓ {len(encounter_details['medications'])} medication(s) prescribed/reviewed")
+                    if encounter_details.get("supplements"):
+                        summary_items.append(f"✓ {len(encounter_details['supplements'])} supplement(s) documented")
+                    if encounter_details.get("lab_orders"):
+                        summary_items.append(f"✓ {len(encounter_details['lab_orders'])} lab order(s)")
                     if encounter_details.get("clinical_notes"):
                         summary_items.append("✓ Clinical notes documented")
                     

--- a/src/tools/scheduling_tools.py
+++ b/src/tools/scheduling_tools.py
@@ -199,7 +199,7 @@ async def manageAppointments(
                     
                 case "reschedule":
                     # Auto-fill missing fields from the existing appointment
-                    if appointment_id and (not patient_id or not facility_id or not provider_id):
+                    if appointment_id and (not patient_id or not facility_id or not provider_id or not visit_type_id):
                         try:
                             appt_response = await client.get(f"/appointment/{appointment_id}")
                             appt = appt_response.get("output_string") or appt_response.get("appointment") or {}
@@ -207,6 +207,8 @@ async def manageAppointments(
                                 patient_id = patient_id or str(appt.get("practice_patient_id", ""))
                                 facility_id = facility_id or str(appt.get("facility_id", ""))
                                 provider_id = provider_id or str(appt.get("member_id", ""))
+                                if not visit_type_id and appt.get("visit_type_id"):
+                                    visit_type_id = int(appt["visit_type_id"])
                                 if mode == "In Person" and appt.get("appointment_type"):
                                     mode = appt["appointment_type"]
                         except Exception as e:
@@ -218,20 +220,21 @@ async def manageAppointments(
                             "error": "Missing required fields for rescheduling",
                             "guidance": "For rescheduling, provide: appointment_id, facility_id, patient_id, provider_id, appointment_date, appointment_time"
                         }
-                    
-                    # Build reschedule data
+
+                    # Build reschedule data (IDs must be integers, matching CharmHealth API Long type)
                     reschedule_data = {
-                        "facility_id": facility_id,
-                        "patient_id": patient_id,
-                        "member_id": provider_id,
+                        "facility_id": int(facility_id),
+                        "patient_id": int(patient_id),
+                        "member_id": int(provider_id),
                         "mode": mode,
                         "repetition": repetition or "Single Date",
                         "start_date": appointment_date.isoformat(),
                         "start_time": appointment_time,
                         "duration_in_minutes": duration_minutes,
                         "appointment_status": status,
-                        "visit_type_id": visit_type_id
                     }
+                    if visit_type_id:
+                        reschedule_data["visit_type_id"] = int(visit_type_id)
                     
                     if reason:
                         reschedule_data["reason"] = reason
@@ -240,9 +243,7 @@ async def manageAppointments(
                     if resource_id:
                         reschedule_data["resource_id"] = resource_id
                     
-                    data = {"data": reschedule_data}
-                    
-                    response = await client.post(f"/appointment/{appointment_id}/reschedule", data=data)
+                    response = await client.post(f"/appointment/{appointment_id}/reschedule", data=reschedule_data)
                     
                     if response.get("output_string"):
                         response["guidance"] = f"Appointment {appointment_id} rescheduled successfully. Patient will be notified of the new time."

--- a/src/tools/scheduling_tools.py
+++ b/src/tools/scheduling_tools.py
@@ -198,6 +198,20 @@ async def manageAppointments(
                     return strip_empty_values(response)
                     
                 case "reschedule":
+                    # Auto-fill missing fields from the existing appointment
+                    if appointment_id and (not patient_id or not facility_id or not provider_id):
+                        try:
+                            appt_response = await client.get(f"/appointment/{appointment_id}")
+                            appt = appt_response.get("output_string") or appt_response.get("appointment") or {}
+                            if appt:
+                                patient_id = patient_id or str(appt.get("practice_patient_id", ""))
+                                facility_id = facility_id or str(appt.get("facility_id", ""))
+                                provider_id = provider_id or str(appt.get("member_id", ""))
+                                if mode == "In Person" and appt.get("appointment_type"):
+                                    mode = appt["appointment_type"]
+                        except Exception as e:
+                            logger.warning(f"Could not auto-fill reschedule fields from appointment {appointment_id}: {e}")
+
                     required = [appointment_id, facility_id, patient_id, provider_id, appointment_date, appointment_time]
                     if not all(required):
                         return {

--- a/src/tools/task_management.py
+++ b/src/tools/task_management.py
@@ -61,7 +61,7 @@ async def manageTasks(
     <instructions>
     Actions:
     - "add": Create new task (requires task, owner_id (look up members using getPracticeInfo()), priority (0-Low, 1-Medium, 2-High, 3-Critical), status (Pending, In-progress, Completed), comments, due_date, reminder_options, tasklist. optional: patient_id if task is related to a patient)
-    - "update": Modify existing task (requires task_id (use manageTasks(action='list') to get task_id) + fields to change)
+    - "update": Modify existing task (requires task_id, task, owner_id, priority, status, tasklist — use manageTasks(action='list') first to get current values, then pass all required fields with your changes)
     - "list": Show tasks with filtering (supports view/date range/pagination plus client-side filters)
     - "change_status": Change the status of a task (requires task_id (use manageTasks(action='list') to get task_id) + new_status (Pending, In-progress, Completed))
 
@@ -144,34 +144,40 @@ async def manageTasks(
                     return strip_empty_values(await client.post("/tasks", data=task_data))
 
                 case "update":
-                    if not task_id:
-                        return {"error": "task_id is required for update"}
+                    missing = [k for k, v in {
+                        "task_id": task_id,
+                        "task": task,
+                        "owner_id": owner_id,
+                        "priority": priority,
+                        "status": status,
+                        "tasklist": tasklist,
+                    }.items() if not v]
+                    if missing:
+                        return {
+                            "error": f"Missing required fields for update: {', '.join(missing)}",
+                            "guidance": "Use manageTasks(action='list') first to retrieve the current task values, then pass all required fields: task_id, task, owner_id, priority, status, tasklist."
+                        }
 
-                    update_data = {}
-                    # identifiers / fields to change
-                    if patient_id:
-                        update_data["patient_id"] = patient_id
-                    if task:
-                        update_data["task"] = task
-                    if owner_id:
-                        update_data["owner_id"] = owner_id
-                    if priority:
-                        update_data["priority"] = priority
-                    if status:
-                        update_data["status"] = status
-                    if comments:
+                    update_data = {
+                        "task": task,
+                        "owner_id": owner_id,
+                        "priority": priority,
+                        "status": status,
+                        "tasklist": tasklist,
+                    }
+                    if comments is not None:
                         update_data["comments"] = comments
                     if due_date:
                         update_data["due_date"] = due_date.isoformat()
                     if reminder_options:
                         update_data["reminder_options"] = reminder_options
-                    if tasklist:
-                        update_data["tasklist"] = tasklist
+                    if patient_id:
+                        update_data["patient_id"] = patient_id
 
-                    if not update_data:
-                        return {"error": "No fields provided to update"}
-
-                    return strip_empty_values(await client.put(f"/tasks/{task_id}", data=update_data))
+                    response = strip_empty_values(await client.put(f"/tasks/{task_id}", data=update_data))
+                    if (response.get("output_string") or {}).get("message", "").startswith("Success"):
+                        response["guidance"] = f"Task {task_id} updated successfully."
+                    return response
 
                 case "list":
                     params = {}


### PR DESCRIPTION
## Summary

- **Add manageMessages and manageFax** — secure portal messaging, SMS, WhatsApp, and fax tools
- **Add supplements and lab orders to encounter review**
- **Fix appointment reschedule** — remove data wrapper, auto-fill visit_type_id, cast IDs to int
- **Fix manageMessages send** — require facility_id for all channels; add type=plain_text for SMS
- **Fix managePatientVitals** — accept entry_date as alternative to encounter_id; fix success check key (vital_entries)
- **Fix manageTasks update** — require all fields explicitly with list-first guidance
- **Fix managePatientAllergies update** — require reactions and allergy_date (API requires despite docs saying optional)
- **Fix managePatientRecalls add/update** — null-free payload; document recall_period requirement; require recall_type + notes on update
- **Remove managePatientLabs add_result** — endpoint requires multipart form + 3-step ID lookup chain; designed for HL7 integration not manual entry (design doc: PLANS/lab-add-result-design.md)
- **Add manageEncounter list** — GET /encounters?patient_id=...
- **Fix managePatientDrugs update/discontinue** — carry encounter_id from existing record; block drug_name/strength changes (catalog fields); fix Extra key JSON error
- **Remove request body logging** — contained PHI

## Test plan

- [x] manageMessages send (secure, SMS channels)
- [x] manageMessages list
- [x] manageAppointments reschedule
- [x] managePatientVitals add (with entry_date, no encounter required)
- [x] managePatientVitals update
- [x] manageTasks update (list → update flow)
- [x] managePatientAllergies update
- [x] managePatientRecalls add
- [x] managePatientRecalls update
- [x] manageEncounter list
- [x] managePatientDrugs update (directions change)
- [x] managePatientDrugs discontinue