### PR TITLE
Fix supplement discontinue and update: carry supplement_name on PUT

### DIFF
--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -664,10 +664,25 @@ async def managePatientDrugs(
                         if response.get("medications"):
                             response["guidance"] = f"Medication {record_id} updated successfully. Changes are now active in the patient's medication profile."
                     else:
-                        # Update supplement
-                        update_data = {}
-                        if drug_name:
-                            update_data["supplement_name"] = drug_name
+                        # GET current supplement to carry supplement_name — API rejects the PUT without it
+                        current_resp = await client.get(f"/patients/{patient_id}/supplements")
+                        current_supps = current_resp.get("supplements", [])
+                        current_supp = next(
+                            (
+                                s for s in current_supps
+                                if str(s.get("supplement_id") or s.get("patient_supplement_id")) == str(record_id)
+                            ),
+                            None,
+                        )
+                        if not current_supp:
+                            return {
+                                "error": f"Supplement record {record_id} not found",
+                                "guidance": "Use action='list' to verify the record_id exists for this patient."
+                            }
+
+                        update_data: Dict[str, Any] = {
+                            "supplement_name": drug_name or current_supp.get("supplement_name", ""),
+                        }
                         if dosage:
                             update_data["dosage"] = dosage
                         if strength:
@@ -676,7 +691,11 @@ async def managePatientDrugs(
                             update_data["status"] = status.title()
                         if frequency:
                             update_data["frequency"] = frequency
-                        
+                        if comments:
+                            update_data["comments"] = comments
+                        elif directions:
+                            update_data["comments"] = directions
+
                         response = await client.put(f"/patients/{patient_id}/supplements/{record_id}", data=update_data)
                         
                         if response.get("supplements"):

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -721,9 +721,30 @@ async def managePatientDrugs(
                         if response.get("medications"):
                             response["guidance"] = f"Medication {record_id} discontinued. Patient should stop taking this medication. Document discontinuation reason in next encounter with manageEncounter()."
                     else:
-                        # Set supplement to inactive
-                        response = await client.put(f"/patients/{patient_id}/supplements/{record_id}", data={"status": "Inactive"})
-                        
+                        # GET current supplement to carry supplement_name — API rejects the PUT without it
+                        current_resp = await client.get(f"/patients/{patient_id}/supplements")
+                        current_supps = current_resp.get("supplements", [])
+                        current_supp = next(
+                            (
+                                s for s in current_supps
+                                if str(s.get("supplement_id") or s.get("patient_supplement_id")) == str(record_id)
+                            ),
+                            None,
+                        )
+                        if not current_supp:
+                            return {
+                                "error": f"Supplement record {record_id} not found",
+                                "guidance": "Use action='list' to verify the record_id exists for this patient."
+                            }
+
+                        response = await client.put(
+                            f"/patients/{patient_id}/supplements/{record_id}",
+                            data={
+                                "supplement_name": current_supp.get("supplement_name", ""),
+                                "status": "Inactive",
+                            },
+                        )
+
                         if response.get("supplements"):
                             response["guidance"] = f"Supplement {record_id} discontinued. This supplement is no longer part of the patient's active regimen."
                     


### PR DESCRIPTION
## Summary

CharmHealth's supplement PUT requires `supplement_name`, but two paths in `managePatientDrugs` built their PUT bodies from user-supplied params only and were rejected by the API:

- **`discontinue`**: sent `{"status": "Inactive"}` with no name.
- **`update`**: sent whatever the caller passed, which omits `supplement_name` for common cases (toggle status, change dosage/frequency/strength).

Both now use the same GET-first pattern already in place for medication discontinue/update: fetch the current record, seed `supplement_name`, then overlay caller-supplied fields.

Also fixes a related drop: `directions` was silently ignored on supplement update. Now mapped to `comments` (matching the supplement add path).

Medication discontinue and update are unchanged — they already used this pattern.

## Test plan

- [x] Verified discontinue live: PUT returned 200 with `status: false`.
- [x] Verified update live with `frequency="Twice a day"` and no `drug_name` — PUT returned 200, `frequency` changed, `supplement_name` carried forward.
- [x] Discontinuing or updating a non-existent record surfaces the "not found" guidance.