### PR TITLE
Ch695 mcp error contract adaptation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,12 @@ dependencies = [
     "prometheus-client>=0.20.0"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -23,3 +29,7 @@ build-backend = "setuptools.build_meta"
 package-dir = {"" = "src"}
 packages = { find = { where = ["src"] } }
 py-modules = ["mcp_server"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/src/telemetry/tool_metrics.py
+++ b/src/telemetry/tool_metrics.py
@@ -1,7 +1,9 @@
 import functools
+import json
 import time
 import logging
 from typing import Dict, Any, Callable, Optional
+from fastmcp.exceptions import ToolError
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from .telemetry_config import telemetry
@@ -74,8 +76,6 @@ def with_tool_metrics(tool_name: Optional[str] = None):
 
                     _record_tool_completion_metrics(actual_tool_name, client_id, start_time, status, is_success)
 
-                    return result
-
                 except Exception as e:
                     client_id = current_client_id.get('unknown')
 
@@ -86,6 +86,11 @@ def with_tool_metrics(tool_name: Optional[str] = None):
                     _record_tool_completion_metrics(actual_tool_name, client_id, start_time, "error", False)
                     logger.error(f"Tool {actual_tool_name} failed with exception: {e}")
                     raise
+                else:
+                    # J13/CH-695: isError flag
+                    if isinstance(result, dict) and "error" in result:
+                        raise ToolError(json.dumps(result, indent=2))
+                    return result
                 finally:
                     # Clear the initial gauge entry if client_id changed mid-call
                     if client_id != initial_client_id:

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -615,8 +615,11 @@ async def managePatientDrugs(
                                 supplement_data[0]["comments"] = directions
                         
                         response = await client.post(f"/patients/{patient_id}/supplements", data=supplement_data)
-                        
+
                         if response.get("supplements"):
+                            for s in response["supplements"]:
+                                if isinstance(s, dict) and "supplement_name" in s:
+                                    s.setdefault("drug_name", s["supplement_name"])
                             response["guidance"] = f"Supplement '{drug_name}' documented successfully. This will appear in the patient's medication list for reference during prescribing."
                     
                     return strip_empty_values(response)
@@ -707,8 +710,11 @@ async def managePatientDrugs(
                             update_data["comments"] = directions
 
                         response = await client.put(f"/patients/{patient_id}/supplements/{record_id}", data=update_data)
-                        
+
                         if response.get("supplements"):
+                            for s in response["supplements"]:
+                                if isinstance(s, dict) and "supplement_name" in s:
+                                    s.setdefault("drug_name", s["supplement_name"])
                             response["guidance"] = f"Supplement {record_id} updated successfully. Changes are reflected in the patient's supplement list."
                     
                     return strip_empty_values(response)
@@ -775,6 +781,9 @@ async def managePatientDrugs(
                         )
 
                         if response.get("supplements"):
+                            for s in response["supplements"]:
+                                if isinstance(s, dict) and "supplement_name" in s:
+                                    s.setdefault("drug_name", s["supplement_name"])
                             response["guidance"] = f"Supplement {record_id} discontinued. This supplement is no longer part of the patient's active regimen."
                     
                     return strip_empty_values(response)

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -490,6 +490,16 @@ async def managePatientDrugs(
                             supps = response.get("supplements", [])
                             total_count = len(supps)
 
+                            # Canonical display-name field (additive,
+                            # J13/CH-695): supplements use supplement_name
+                            # instead of drug_name — cortex's entity-cache
+                            # convention only looks for drug_name for this
+                            # entity type, so expose it here too rather than
+                            # teaching cortex a second field name.
+                            for s in supps:
+                                if isinstance(s, dict) and "supplement_name" in s:
+                                    s.setdefault("drug_name", s["supplement_name"])
+
                             wrappers = []
                             for s in supps:
                                 derived_status = str((s or {}).get("status", "")).casefold()

--- a/src/tools/clinical_support.py
+++ b/src/tools/clinical_support.py
@@ -605,7 +605,9 @@ async def managePatientLabs(
     no_of_records: Optional[int] = None,
     sort_by: Optional[Literal["DATE", "FULL_NAME"]] = None,
     is_ascending: Optional[bool] = None,
-    
+
+    response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """

--- a/src/tools/core_tools.py
+++ b/src/tools/core_tools.py
@@ -48,7 +48,9 @@ async def findPatients(
     sort_by: Optional[Literal["name", "created_date", "modified_date"]] = "name",
     sort_order: Optional[Literal["asc", "desc"]] = "asc",
     page: Optional[int] = 1,
-    
+
+    response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """

--- a/src/tools/core_tools.py
+++ b/src/tools/core_tools.py
@@ -230,7 +230,15 @@ async def findPatients(
                     params["is_phr_account_available"] = has_phr_account
             
             response = await client.get("/patients", params=params)
-            
+
+            # Canonical display-name field (additive, J13/CH-695): /patients
+            # already returns full_name (persisted, server-computed) per
+            # patient — just expose it under the name cortex's entity-cache
+            # convention expects too, without touching the existing field.
+            for _patient in response.get("patients") or []:
+                if isinstance(_patient, dict) and "full_name" in _patient:
+                    _patient.setdefault("patient_name", _patient["full_name"])
+
             # Enhanced response with intelligent guidance
             if response.get("patients"):
                 patient_count = len(response["patients"])
@@ -372,7 +380,18 @@ async def getPracticeInfo(
     ) as client:
         try:
             result = {"practice_info_type": info_type}
-            
+
+            def _add_provider_name(providers: list) -> list:
+                # Canonical display-name field (additive, J13/CH-695):
+                # /members already returns full_name (persisted,
+                # server-computed) per provider — expose it under the name
+                # cortex's entity-cache convention expects too, without
+                # touching the existing field.
+                for provider in providers:
+                    if isinstance(provider, dict) and "full_name" in provider:
+                        provider.setdefault("provider_name", provider["full_name"])
+                return providers
+
             # Use match for single-purpose info types, handle overview separately
             match info_type:
                 case "facilities":
@@ -382,7 +401,7 @@ async def getPracticeInfo(
                 case "providers":
                     # Get providers (members with sign encounter privilege)
                     providers_response = await client.get("/members", params={"privilege": "sign_encounter"})
-                    result["providers"] = providers_response.get("members", [])
+                    result["providers"] = _add_provider_name(providers_response.get("members", []))
                     result["guidance"] = "Use provider IDs (member_id) from this list when scheduling appointments or documenting encounters. Only providers with 'sign_encounter' privilege can sign clinical documentation."
                 case "vitals":
                     vitals_response = await client.get("/vitals/metrics")
@@ -395,7 +414,7 @@ async def getPracticeInfo(
                     result["facility_count"] = len(result["facilities"])
 
                     providers_response = await client.get("/members", params={"privilege": "sign_encounter"})
-                    result["providers"] = providers_response.get("members", [])
+                    result["providers"] = _add_provider_name(providers_response.get("members", []))
                     result["provider_count"] = len(result["providers"])
 
                     vitals_response = await client.get("/vitals/metrics")

--- a/src/tools/core_tools.py
+++ b/src/tools/core_tools.py
@@ -396,34 +396,34 @@ async def getPracticeInfo(
             match info_type:
                 case "facilities":
                     facilities_response = await client.get("/facilities")
-                    result["facilities"] = facilities_response.get("facilities", [])
+                    result["facilities"] = facilities_response.get("facilities") or []
                     result["guidance"] = "Use facility IDs from this list when scheduling appointments or creating encounters. Each patient must be assigned to at least one facility."
                 case "providers":
                     # Get providers (members with sign encounter privilege)
                     providers_response = await client.get("/members", params={"privilege": "sign_encounter"})
-                    result["providers"] = _add_provider_name(providers_response.get("members", []))
+                    result["providers"] = _add_provider_name(providers_response.get("members") or [])
                     result["guidance"] = "Use provider IDs (member_id) from this list when scheduling appointments or documenting encounters. Only providers with 'sign_encounter' privilege can sign clinical documentation."
                 case "vitals":
                     vitals_response = await client.get("/vitals/metrics")
-                    result["available_vitals"] = vitals_response.get("vitals", [])
+                    result["available_vitals"] = vitals_response.get("vitals") or []
                     result["guidance"] = "Use these vital sign names when documenting patient vitals in encounters. Common vitals include Weight, Height, Blood Pressure, Pulse Rate, Temperature."
                 case "overview":
                     # Get all data for overview
                     facilities_response = await client.get("/facilities")
-                    result["facilities"] = facilities_response.get("facilities", [])
+                    result["facilities"] = facilities_response.get("facilities") or []
                     result["facility_count"] = len(result["facilities"])
 
                     providers_response = await client.get("/members", params={"privilege": "sign_encounter"})
-                    result["providers"] = _add_provider_name(providers_response.get("members", []))
+                    result["providers"] = _add_provider_name(providers_response.get("members") or [])
                     result["provider_count"] = len(result["providers"])
 
                     vitals_response = await client.get("/vitals/metrics")
-                    result["available_vitals"] = vitals_response.get("vitals", [])
+                    result["available_vitals"] = vitals_response.get("vitals") or []
                     result["vital_types_count"] = len(result["available_vitals"])
 
                     try:
                         templates_response = await client.get("/templates", params={"template_filter": "all_templates", "per_page": 100})
-                        result["templates"] = templates_response.get("templates", [])
+                        result["templates"] = templates_response.get("templates") or []
                         result["template_count"] = len(result["templates"])
                     except Exception as e:
                         logger.warning(f"Could not fetch templates in overview: {e}")
@@ -434,7 +434,7 @@ async def getPracticeInfo(
 
                 case "templates":
                     templates_response = await client.get("/templates", params={"template_filter": "all_templates", "per_page": 100})
-                    result["templates"] = templates_response.get("templates", [])
+                    result["templates"] = templates_response.get("templates") or []
                     result["template_count"] = len(result["templates"])
                     result["guidance"] = "Use template_id values from this list with info_type='template_details' to fetch full entry schemas. Filter by template_type (e.g. 'SOAP', 'Chief Complaints', 'Symptoms', 'Physical Examination', 'Assessment Notes', 'Diagnosis') to find relevant templates."
 
@@ -445,7 +445,7 @@ async def getPracticeInfo(
                             "guidance": "Provide comma-separated template IDs. Use info_type='templates' first to get available template IDs."
                         }
                     soap_response = await client.get("/soap/templates", params={"template_ids": template_ids})
-                    result["soap_templates"] = soap_response.get("soap_templates", [])
+                    result["soap_templates"] = soap_response.get("soap_templates") or []
                     result["guidance"] = "Each soap_template contains soap_templates_inner (widget placements) → soap_widgets → soap_widget_entries. Use entry_id values when populating entries in manageEncounter(action='update'). Entry types: 'Simple Question'/'Text Box'/'Radio' → free text; 'Yes/No Question' → 'Yes' or 'No'; 'Header' → skip (display only)."
             
             logger.info(f"getPracticeInfo completed for {info_type}")

--- a/src/tools/encounter_management.py
+++ b/src/tools/encounter_management.py
@@ -190,6 +190,10 @@ async def manageEncounter(
                         "encounter_id": found_encounter.get("encounter_id"),
                         "encounter_date": found_encounter.get("date"),  # Changed from encounter_date
                         "provider": found_encounter.get("physician_name"),  # Changed from provider_name
+                        # Canonical display-name field (additive, J13/CH-695):
+                        # same source as "provider" above, just under the key
+                        # cortex's entity-cache convention expects.
+                        "provider_name": found_encounter.get("physician_name"),
                         "facility": found_encounter.get("facility_id"),  # Note: This is ID not name
                         "encounter_mode": found_encounter.get("appointment_mode"),  # Changed from encounter_mode
                         "visit_type": found_encounter.get("visit_name"),  # Changed from visit_type

--- a/src/tools/encounter_management.py
+++ b/src/tools/encounter_management.py
@@ -35,6 +35,8 @@ async def manageEncounter(
     per_page: Optional[int] = None,
     page: Optional[int] = None,
 
+    response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """

--- a/src/tools/patient_management.py
+++ b/src/tools/patient_management.py
@@ -391,11 +391,16 @@ async def managePatient(
                         patient_data["duplicate_check"] = duplicate_check
                     
                     response = await client.post("/patients", data=patient_data)
-                    
+
                     if response.get("patient"):
                         new_patient_id = response["patient"].get("patient_id")
+                        # Canonical display-name field (additive, J13/CH-695):
+                        # this response mirrors GET /patients/{id}, which
+                        # already returns full_name (persisted, server-computed).
+                        if "full_name" in response["patient"]:
+                            response["patient"].setdefault("patient_name", response["patient"]["full_name"])
                         response["guidance"] = f"Patient created successfully with ID: {new_patient_id}. Complete demographic and social history captured. Use reviewPatientHistory('{new_patient_id}') to view full details or manageAppointments() to schedule their first visit."
-                    
+
                     return strip_empty_values(response)
                     
                 case "update":
@@ -629,11 +634,15 @@ async def managePatient(
                         patient_data["duplicate_check"] = duplicate_check
                     
                     response = await client.put(f"/patients/{patient_id}", data=patient_data)
-                    
+
                     if response.get("patient"):
+                        # Canonical display-name field (additive, J13/CH-695) —
+                        # same rationale as the "create" action above.
+                        if "full_name" in response["patient"]:
+                            response["patient"].setdefault("patient_name", response["patient"]["full_name"])
                         update_mode = "specific fields" if update_specific_details else "complete record"
                         response["guidance"] = f"Patient {patient_id} updated successfully ({update_mode}). Use reviewPatientHistory('{patient_id}') to see the updated information."
-                    
+
                     return strip_empty_values(response)
                     
                 case "activate":

--- a/src/tools/patient_management.py
+++ b/src/tools/patient_management.py
@@ -120,7 +120,9 @@ async def managePatient(
     send_phr_invite: Optional[bool] = False,
     duplicate_check: Optional[bool] = True,
     update_specific_details: Optional[bool] = True,
-    
+
+    response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """
@@ -684,6 +686,9 @@ async def reviewPatientHistory(
     supplement_status_filter: Optional[str] = None,
     vitals_limit: Optional[int] = None,
     encounters_limit: Optional[int] = None,
+
+    response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """

--- a/src/tools/scheduling_tools.py
+++ b/src/tools/scheduling_tools.py
@@ -312,6 +312,14 @@ async def manageAppointments(
                         provider_id_val = (a or {}).get("member_id") or (a or {}).get("provider_id")
                         provider_name_val = (a or {}).get("member_name") or (a or {}).get("physician_name")
                         provider_search = f"{provider_id_val or ''} {provider_name_val or ''}".strip()
+                        # Canonical display-name field (additive, J13/CH-695):
+                        # previously provider_name_val was only computed for
+                        # this internal search string, then discarded — the
+                        # returned appointment item itself never carried it.
+                        # Attach it to the raw item (a is what "_orig" below
+                        # points at and actually gets returned).
+                        if isinstance(a, dict) and provider_name_val:
+                            a.setdefault("provider_name", provider_name_val)
                         wrappers.append({
                             **(a or {}),
                             "_orig": a,

--- a/src/tools/scheduling_tools.py
+++ b/src/tools/scheduling_tools.py
@@ -62,7 +62,9 @@ async def manageAppointments(
     provider_filter: Optional[str] = None,  # provider_id or provider_name (substring match)
     mode_filter: Optional[str] = None,
     limit: Optional[int] = None,
-    
+
+    response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
+
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """

--- a/src/tools/task_management.py
+++ b/src/tools/task_management.py
@@ -213,7 +213,7 @@ async def manageTasks(
                         owner = task.get("owner") if isinstance(task, dict) else None
                         if isinstance(owner, dict):
                             if "member_id" in owner:
-                                task.setdefault("owner_id", owner["member_id"])
+                                task.setdefault("owner_id", str(owner["member_id"]))
                             if "full_name" in owner:
                                 task.setdefault("owner_name", owner["full_name"])
 

--- a/src/tools/task_management.py
+++ b/src/tools/task_management.py
@@ -201,6 +201,22 @@ async def manageTasks(
                     tasks = response.get("tasks") or []
                     total_count = len(tasks)
 
+                    # Canonical flat owner_id/owner_name fields (additive,
+                    # J13/CH-695): /tasks returns owner as a nested object
+                    # ({member_id, full_name, prefix}), not flat fields —
+                    # but manageTasks' own "add"/"update" actions accept a
+                    # flat owner_id argument, and cortex's entity-cache
+                    # convention expects flat owner_id/owner_name too. Add
+                    # both alongside the existing nested "owner" object
+                    # (left untouched) rather than replacing it.
+                    for task in tasks:
+                        owner = task.get("owner") if isinstance(task, dict) else None
+                        if isinstance(owner, dict):
+                            if "member_id" in owner:
+                                task.setdefault("owner_id", owner["member_id"])
+                            if "full_name" in owner:
+                                task.setdefault("owner_name", owner["full_name"])
+
                     def _normalize_priority(p: Optional[str]) -> Optional[str]:
                         if p is None:
                             return None

--- a/tests/test_entity_name_fields.py
+++ b/tests/test_entity_name_fields.py
@@ -1,0 +1,202 @@
+"""Tests for canonical <entity>_name fields (J13/CH-695, task 5 prep).
+
+Additive only: each tool already returns some raw field with the display
+name (full_name, supplement_name, or a nested owner object) — these tests
+confirm the new canonical field is added alongside it, with the same
+value, without disturbing the original field. Fakes CharmHealthAPIClient
+so no real network/API access is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools import core_tools, patient_management, clinical_data, task_management, encounter_management, scheduling_tools
+
+
+class _FakeAPIClient:
+    """Stands in for CharmHealthAPIClient — returns canned responses keyed
+    by exact endpoint string, per HTTP method."""
+
+    def __init__(self, get_responses=None, post_responses=None, put_responses=None):
+        self._get = get_responses or {}
+        self._post = post_responses or {}
+        self._put = put_responses or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, endpoint, params=None):
+        return self._get[endpoint]
+
+    async def post(self, endpoint, data=None, params=None):
+        return self._post[endpoint]
+
+    async def put(self, endpoint, data=None, params=None):
+        return self._put[endpoint]
+
+
+def _patch_client(monkeypatch, module, fake_client) -> None:
+    monkeypatch.setattr(module, "CharmHealthAPIClient", lambda **kwargs: fake_client)
+
+
+@pytest.mark.asyncio
+async def test_find_patients_adds_patient_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/patients": {"patients": [
+            {"id": "p1", "first_name": "Jane", "last_name": "Smith", "full_name": "Jane Smith"},
+        ]},
+    })
+    _patch_client(monkeypatch, core_tools, fake)
+
+    result = await core_tools.findPatients.fn(query="Jane")
+
+    patient = result["patients"][0]
+    assert patient["full_name"] == "Jane Smith"
+    assert patient["patient_name"] == "Jane Smith"
+
+
+@pytest.mark.asyncio
+async def test_get_practice_info_providers_adds_provider_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/members": {"members": [
+            {"member_id": "m1", "first_name": "Alex", "last_name": "Doe", "full_name": "Alex Doe"},
+        ]},
+    })
+    _patch_client(monkeypatch, core_tools, fake)
+
+    result = await core_tools.getPracticeInfo.fn(info_type="providers")
+
+    provider = result["providers"][0]
+    assert provider["full_name"] == "Alex Doe"
+    assert provider["provider_name"] == "Alex Doe"
+
+
+@pytest.mark.asyncio
+async def test_manage_patient_create_adds_patient_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={
+        "/patients": {"patient": {
+            "patient_id": "p1", "first_name": "Jane", "last_name": "Smith", "full_name": "Jane Smith",
+        }},
+    })
+    _patch_client(monkeypatch, patient_management, fake)
+
+    result = await patient_management.managePatient.fn(
+        action="create", first_name="Jane", last_name="Smith",
+        gender="female", facility_ids="1", age="30",
+    )
+
+    assert result["patient"]["patient_name"] == "Jane Smith"
+    assert result["patient"]["full_name"] == "Jane Smith"
+
+
+@pytest.mark.asyncio
+async def test_manage_patient_update_adds_patient_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={
+            "/patients/p1": {"patient": {
+                "patient_id": "p1", "first_name": "Jane", "last_name": "Smith",
+                "gender": "female", "dob": "1990-01-01", "facilities": [],
+            }},
+        },
+        put_responses={
+            "/patients/p1": {"patient": {
+                "patient_id": "p1", "first_name": "Jane", "last_name": "Smith", "full_name": "Jane Smith",
+            }},
+        },
+    )
+    _patch_client(monkeypatch, patient_management, fake)
+
+    result = await patient_management.managePatient.fn(action="update", patient_id="p1")
+
+    assert result["patient"]["patient_name"] == "Jane Smith"
+
+
+@pytest.mark.asyncio
+async def test_manage_patient_drugs_list_supplements_adds_drug_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/patients/p1/supplements": {"supplements": [
+            {"supplement_id": "s1", "supplement_name": "Vitamin D3", "status": "Active"},
+        ]},
+    })
+    _patch_client(monkeypatch, clinical_data, fake)
+
+    result = await clinical_data.managePatientDrugs.fn(
+        action="list", patient_id="p1", substance_type="supplement",
+    )
+
+    supplement = result["supplements"][0]
+    assert supplement["supplement_name"] == "Vitamin D3"
+    assert supplement["drug_name"] == "Vitamin D3"
+
+
+@pytest.mark.asyncio
+async def test_manage_tasks_list_flattens_owner_id_and_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/tasks": {"tasks": [
+            {
+                "task_id": "t1", "task": "Follow up",
+                "owner": {"member_id": "m1", "full_name": "Alex Doe", "prefix": "Dr."},
+            },
+        ]},
+    })
+    _patch_client(monkeypatch, task_management, fake)
+
+    result = await task_management.manageTasks.fn(action="list")
+
+    task = result["tasks"][0]
+    assert task["owner"] == {"member_id": "m1", "full_name": "Alex Doe", "prefix": "Dr."}
+    assert task["owner_id"] == "m1"
+    assert task["owner_name"] == "Alex Doe"
+
+
+@pytest.mark.asyncio
+async def test_manage_encounter_review_adds_provider_name(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/encounters": {"encounters": [
+            {"encounter_id": "e1", "physician_name": "Dr. Alex Doe", "date": "2026-07-01",
+             "facility_id": "f1", "appointment_mode": "In Person", "visit_name": "Follow-up",
+             "is_approved": "true"},
+        ]},
+        "/patients/p1": {"patient": {"patient_id": "p1"}},
+        "/patients/p1/vitals": {"vital_entries": []},
+        "/patients/p1/diagnoses": {"diagnoses": []},
+        "/patients/p1/medications": {"medications": []},
+        "/patients/p1/supplements": {"supplements": []},
+        "/patients/p1/lab-orders": {"lab_orders": []},
+    })
+    _patch_client(monkeypatch, encounter_management, fake)
+
+    result = await encounter_management.manageEncounter.fn(
+        patient_id="p1", action="review", encounter_id="e1",
+    )
+
+    info = result["encounter_details"]["encounter_info"]
+    assert info["provider"] == "Dr. Alex Doe"
+    assert info["provider_name"] == "Dr. Alex Doe"
+
+
+@pytest.mark.asyncio
+async def test_manage_appointments_list_adds_provider_name(monkeypatch) -> None:
+    import datetime
+
+    fake = _FakeAPIClient(get_responses={
+        "/appointments": {"appointments": [
+            {"appointment_id": "a1", "member_id": "m1", "physician_name": "Dr. Alex Doe",
+             "appointment_status": "Confirmed"},
+        ]},
+    })
+    _patch_client(monkeypatch, scheduling_tools, fake)
+
+    result = await scheduling_tools.manageAppointments.fn(
+        action="list",
+        start_date=datetime.date(2026, 7, 1),
+        end_date_range=datetime.date(2026, 7, 31),
+        facility_ids="1",
+    )
+
+    appt = result["appointments"][0]
+    assert appt["provider_name"] == "Dr. Alex Doe"

--- a/tests/test_response_format_param.py
+++ b/tests/test_response_format_param.py
@@ -1,0 +1,82 @@
+"""Tests for the response_format param on detail-view tools (J13 / CH-695, task 3).
+
+Additive only: the param must be accepted (and validated) without changing
+any tool's behavior. These tests check the generated JSON schema and the
+same jsonschema validation the MCP SDK runs before a tool ever executes —
+no network calls, so no need to mock CharmHealthAPIClient.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import jsonschema
+import pytest
+
+import mcp_server
+
+DETAIL_VIEW_TOOLS_WITH_MIN_ARGS = {
+    "manageEncounter": {"patient_id": "p1"},
+    "managePatientLabs": {"action": "list"},
+    "findPatients": {},
+    "manageAppointments": {"action": "list"},
+    "managePatient": {"action": "create"},
+    "reviewPatientHistory": {"patient_id": "p1"},
+}
+
+
+@pytest.fixture(scope="module")
+def tools() -> dict:
+    return asyncio.run(mcp_server.mcp_composite_server.get_tools())
+
+
+@pytest.mark.parametrize("tool_name", DETAIL_VIEW_TOOLS_WITH_MIN_ARGS)
+def test_tool_advertises_response_format(tool_name: str, tools: dict) -> None:
+    tool = tools[tool_name]
+    schema = tool.parameters["properties"]["response_format"]
+    allowed = {"concise", "detailed", None}
+
+    enum_values = set()
+    for option in schema["anyOf"]:
+        if "enum" in option:
+            enum_values.update(option["enum"])
+        elif option.get("type") == "null":
+            enum_values.add(None)
+
+    assert enum_values == allowed
+    assert schema["default"] is None
+
+
+@pytest.mark.parametrize("tool_name,min_args", DETAIL_VIEW_TOOLS_WITH_MIN_ARGS.items())
+def test_response_format_detailed_passes_schema_validation(
+    tool_name: str, min_args: dict, tools: dict,
+) -> None:
+    tool = tools[tool_name]
+    arguments = {**min_args, "response_format": "detailed"}
+
+    # Same validation the MCP SDK runs before invoking the tool function
+    # (mcp/server/lowlevel/server.py: jsonschema.validate(instance=arguments,
+    # schema=tool.inputSchema)) — proves cortex's injected argument is
+    # accepted, without needing to hit the real CharmHealth API.
+    jsonschema.validate(instance=arguments, schema=tool.parameters)
+
+
+@pytest.mark.parametrize("tool_name,min_args", DETAIL_VIEW_TOOLS_WITH_MIN_ARGS.items())
+def test_response_format_omitted_still_passes_schema_validation(
+    tool_name: str, min_args: dict, tools: dict,
+) -> None:
+    # No behavior/validation change for callers who don't pass it at all —
+    # this is what every caller does today.
+    tool = tools[tool_name]
+    jsonschema.validate(instance=min_args, schema=tool.parameters)
+
+
+@pytest.mark.parametrize("tool_name,min_args", DETAIL_VIEW_TOOLS_WITH_MIN_ARGS.items())
+def test_invalid_response_format_value_fails_schema_validation(
+    tool_name: str, min_args: dict, tools: dict,
+) -> None:
+    tool = tools[tool_name]
+    arguments = {**min_args, "response_format": "loud"}
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=arguments, schema=tool.parameters)

--- a/tests/test_tool_metrics.py
+++ b/tests/test_tool_metrics.py
@@ -1,0 +1,83 @@
+"""Tests for with_tool_metrics — isError signaling (J13 / CH-695).
+
+A tool's own return dict (error/guidance keys) must stay byte-identical;
+the only new behavior is raising ToolError so FastMCP flags isError=True.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from telemetry.tool_metrics import with_tool_metrics
+
+
+@pytest.mark.asyncio
+async def test_success_dict_is_returned_unchanged() -> None:
+    @with_tool_metrics()
+    async def fake_tool() -> dict:
+        return {"status": "ok", "guidance": "next call the thing"}
+
+    result = await fake_tool()
+
+    assert result == {"status": "ok", "guidance": "next call the thing"}
+
+
+@pytest.mark.asyncio
+async def test_error_dict_raises_tool_error_with_identical_json() -> None:
+    error_payload = {"error": "Patient not found", "guidance": "Verify the patient_id"}
+
+    @with_tool_metrics()
+    async def fake_tool() -> dict:
+        return error_payload
+
+    with pytest.raises(ToolError) as exc_info:
+        await fake_tool()
+
+    # Message must be the exact same JSON the caller would have seen as
+    # plain content before this change — same keys, same formatting.
+    assert str(exc_info.value) == json.dumps(error_payload, indent=2)
+    assert json.loads(str(exc_info.value)) == error_payload
+
+
+@pytest.mark.asyncio
+async def test_error_dict_still_contains_error_and_guidance_keys() -> None:
+    # Guards against ever stripping these keys — the iOS app in prod
+    # detects failures by sniffing the "error" key in the response text.
+    error_payload = {"error": "Appointment slot unavailable", "guidance": "Pick another time"}
+
+    @with_tool_metrics()
+    async def fake_tool() -> dict:
+        return error_payload
+
+    with pytest.raises(ToolError) as exc_info:
+        await fake_tool()
+
+    parsed = json.loads(str(exc_info.value))
+    assert "error" in parsed
+    assert "guidance" in parsed
+
+
+@pytest.mark.asyncio
+async def test_real_exception_still_propagates_unmodified() -> None:
+    @with_tool_metrics()
+    async def fake_tool() -> dict:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await fake_tool()
+
+
+@pytest.mark.asyncio
+async def test_non_dict_result_passes_through_without_raising() -> None:
+    # Defensive: a tool that (atypically) returns a non-dict must not be
+    # mistaken for an error payload just because "error" can't be a key of it.
+    @with_tool_metrics()
+    async def fake_tool() -> list:
+        return [1, 2, 3]
+
+    result = await fake_tool()
+
+    assert result == [1, 2, 3]

--- a/uv.lock
+++ b/uv.lock
@@ -86,9 +86,14 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-exporter-prometheus" },
     { name = "prometheus-client" },
     { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -98,10 +103,12 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.36.0" },
     { name = "opentelemetry-distro", specifier = ">=0.57b0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.36.0" },
-    { name = "opentelemetry-exporter-prometheus", specifier = ">=0.57b0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "charset-normalizer"
@@ -362,6 +369,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -658,20 +674,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-prometheus"
-version = "0.57b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/d8/5f04c6d51c0823c3d8ac973a2a38db6fcf2d040ca3f08fc66b3c14b6e164/opentelemetry_exporter_prometheus-0.57b0.tar.gz", hash = "sha256:9eb15bdc189235cf03c3f93abf56f8ff0ab57a493a189263bd7fe77a4249e689", size = 14906, upload-time = "2025-07-29T15:12:09.96Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/1c/40fb93a7b7e495985393bbc734104d5d20e470811644dd56c2402d683739/opentelemetry_exporter_prometheus-0.57b0-py3-none-any.whl", hash = "sha256:c5b893d1cdd593fb022af2c7de3258c2d5a4d04402ae80d9fa35675fed77f05c", size = 12922, upload-time = "2025-07-29T15:11:54.055Z" },
-]
-
-[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.57b0"
 source = { registry = "https://pypi.org/simple" }
@@ -750,6 +752,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -860,6 +871,34 @@ name = "pyperclip"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b63cdff36cd398d9701d26cda58e3ab97ac79fb5e60d/pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310", size = 20961, upload-time = "2024-06-18T20:38:48.401Z" }
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
 
 [[package]]
 name = "python-dotenv"


### PR DESCRIPTION
**Summary**

**isError**: with_tool_metrics() now raises fastmcp.exceptions.ToolError whenever a tool's own return dict already has an "error" key — flips protocol-level isError=true without touching any of the 50+ individual tool files. 
Purely additive: existing error/guidance JSON stays byte-identical, so the CharmAnywhere iOS app's key-sniffing keeps working unchanged.
**response_format:** adds an optional response_format: Literal["concise","detailed"] param to the 6 detail-view tools cortex needs. No "concise" mode exists yet — accepted and currently a no-op.
**adds canonical <entity>_name fields** (patient_name, provider_name, owner_id/owner_name, drug_name) across findPatients, managePatient, getPracticeInfo, manageEncounter, manageAppointments, manageTasks, managePatientDrugs — additive, existing fields untouched. This is what unblocks cortex's entity_cache from eventually dropping its guessing heuristic.

**Test plan**
test_tool_metrics.py, test_response_format_param.py, test_entity_name_fields.py — 37 passed.
Jira: [CH-722](https://charmhealthtech.atlassian.net/browse/CH-722) parent [CH-695](https://charmhealthtech.atlassian.net/browse/CH-695)

[CH-722]: https://charmhealthtech.atlassian.net/browse/CH-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ