### PR TITLE
Ch733 mcp action coverage

### DIFF
--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -145,6 +145,7 @@ class CharmHealthAPIClient:
         }
 
         async with httpx.AsyncClient() as client:
+            response = None
             try:
                 response = await client.post(
                     self.token_url,
@@ -175,7 +176,13 @@ class CharmHealthAPIClient:
                 return new_token
 
             except Exception as e:
-                logger.error(f"Failed to refresh token: {e} with response: {response.text}")
+                # `response` can still be None here — client.post() itself can raise
+                # (connection refused, DNS failure, timeout) before it's ever assigned,
+                # and referencing response.text unconditionally would replace that real
+                # error with an UnboundLocalError, undermining the "a failed refresh
+                # returns a clean error" goal this whole retry path exists for.
+                response_detail = response.text if response is not None else "no response received"
+                logger.error(f"Failed to refresh token: {e} with response: {response_detail}")
                 raise
     
     async def _make_request(self, method: str, endpoint: str, params: Optional[Dict[str, Any]] = None, data: Optional[Dict[str, Any]] = None, retry_count: int = 0, auth_retried: bool = False) -> Dict[str, Any]:

--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -224,9 +224,6 @@ class CharmHealthAPIClient:
             logger.error(f"Token refresh failed while preparing request to {endpoint}: {e}")
             return {"error": f"Token refresh failed: {e}"}
 
-        auth_header = headers.get("Authorization", "")
-        auth_preview = f"{auth_header[:20]}...({len(auth_header)} chars)" if auth_header else "MISSING"
-
         try:
             match method:
                 case "GET":

--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -192,12 +192,25 @@ class CharmHealthAPIClient:
 
         api_success = False
 
+        # Fetching headers is deliberately in its own try/except, separate from the
+        # request try/except below. _get_auth_headers() -> _refresh_token() can raise
+        # httpx.HTTPStatusError if the OAuth TOKEN endpoint itself returns a non-2xx
+        # (e.g. a 401 for a bad/rotated client_secret) — if that were allowed to reach
+        # the request try/except's `except httpx.HTTPStatusError as e:` clause below,
+        # `e.response` would be the OAuth server's response, not the target API's, and
+        # the status_code==401-triggers-a-refresh-and-retry logic there would wrongly
+        # fire a second, unwanted refresh for a problem a second refresh cannot fix
+        # (bad client_secret), plus mislabel the OAuth server's error as the target
+        # endpoint's. Catching it here first, before that logic ever sees it, avoids both.
         try:
-            # Inside the try (not before it) so a failed refresh — e.g. a dead
-            # refresh_token — is caught below and returned as a clean error,
-            # instead of propagating as an unhandled exception that skips the
-            # metrics recording and shows up to the caller as a raw ValueError.
             headers = await self._get_auth_headers()
+        except Exception as e:
+            duration = time.time() - start_time
+            record_api_call(self.client_id, False, clean_endpoint, method, duration)
+            logger.error(f"Token refresh failed while preparing request to {endpoint}: {e}")
+            return {"error": f"Token refresh failed: {e}"}
+
+        try:
             match method:
                 case "GET":
                     response = await self._client.get(endpoint, params=params, headers=headers, timeout=self.timeout)

--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -207,6 +207,13 @@ class CharmHealthAPIClient:
         except Exception as e:
             duration = time.time() - start_time
             record_api_call(self.client_id, False, clean_endpoint, method, duration)
+            # start_api_call() above set the gauge active — this early return skips
+            # the `finally` below (it belongs to the second try), so without this the
+            # gauge for this (endpoint, method, client_id) sticks at "in flight"
+            # forever. A dead refresh token sends every call down this path, so the
+            # dashboard would read as permanently stuck mid-request during the exact
+            # incident this code exists to handle.
+            end_api_call(self.client_id, clean_endpoint, method, duration, False)
             logger.error(f"Token refresh failed while preparing request to {endpoint}: {e}")
             return {"error": f"Token refresh failed: {e}"}
 
@@ -281,8 +288,10 @@ class CharmHealthAPIClient:
             return {"error": f"Request failed: {e}"}
 
         except Exception as e:
-            # Record failed API call (also catches a failed token refresh from
-            # _get_auth_headers() above, now that it runs inside this try)
+            # Record failed API call. Token-refresh failures are caught by their
+            # own isolated try/except above (since 96731d7) and never reach here —
+            # this branch is for genuinely unexpected errors in the request/response
+            # handling above (e.g. an httpx internal error, a bad response.json()).
             duration = time.time() - start_time
             record_api_call(self.client_id, False, clean_endpoint, method, duration)
             logger.error(f"Unexpected error: {e}")

--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -178,22 +178,26 @@ class CharmHealthAPIClient:
                 logger.error(f"Failed to refresh token: {e} with response: {response.text}")
                 raise
     
-    async def _make_request(self, method: str, endpoint: str, params: Optional[Dict[str, Any]] = None, data: Optional[Dict[str, Any]] = None, retry_count: int = 0) -> Dict[str, Any]:
+    async def _make_request(self, method: str, endpoint: str, params: Optional[Dict[str, Any]] = None, data: Optional[Dict[str, Any]] = None, retry_count: int = 0, auth_retried: bool = False) -> Dict[str, Any]:
         logger.info(f"Making {method} request to {endpoint}")
         await self.ensure_client()
-        headers = await self._get_auth_headers()
         start_time = time.time()
-        
+
         # Remove any IDs from endpoint for metrics (an ID is an 18 digit number either between / and / or at the end)
         clean_endpoint = re.sub(r'/[0-9]{18}$', '', endpoint)
         clean_endpoint = re.sub(r'/[0-9]{18}/', '/', clean_endpoint)
-        
+
         # Mark API call as starting
         start_api_call(self.client_id, clean_endpoint, method)
-        
+
         api_success = False
-        
+
         try:
+            # Inside the try (not before it) so a failed refresh — e.g. a dead
+            # refresh_token — is caught below and returned as a clean error,
+            # instead of propagating as an unhandled exception that skips the
+            # metrics recording and shows up to the caller as a raw ValueError.
+            headers = await self._get_auth_headers()
             match method:
                 case "GET":
                     response = await self._client.get(endpoint, params=params, headers=headers, timeout=self.timeout)
@@ -227,8 +231,17 @@ class CharmHealthAPIClient:
             duration = time.time() - start_time
             record_api_call(self.client_id, False, clean_endpoint, method, duration)
             
-            if e.response.status_code == 401 and retry_count < self.max_retries:
-                logger.warning("Received 401, forcing token refresh")
+            if e.response.status_code == 401 and not auth_retried:
+                # Refresh and retry exactly once per request, regardless of max_retries.
+                # A 401 that survives a *freshly refreshed* token means the token was
+                # never the problem (e.g. the account's OAuth grant lacks the scope this
+                # endpoint needs) — retrying up to max_retries times would just repeat
+                # that same failure while repeatedly wiping the shared token cache
+                # (_shared_token_cache is keyed by client_id+refresh_token, so it's shared
+                # by every other in-flight call using the same credentials) for no benefit,
+                # and risks compounding a real refresh-token problem if the one refresh
+                # this does perform also fails.
+                logger.warning("Received 401, forcing a single token refresh and retry")
                 self._auth_token = None
                 self._token_expires_at = 0
                 try:
@@ -236,26 +249,27 @@ class CharmHealthAPIClient:
                     self.__class__._shared_token_cache.pop(key, None)
                 except Exception:
                     pass
-                return await self._make_request(method, endpoint, params, data, retry_count + 1)
+                return await self._make_request(method, endpoint, params, data, retry_count, auth_retried=True)
             logger.error(f"HTTP error {e.response.status_code}: {e}")
             logger.error(f"Response body: {e.response.text}")
             return {"error": f"HTTP {e.response.status_code}: {e.response.text}"}
-            
+
         except httpx.RequestError as e:
             # Record failed API call
             duration = time.time() - start_time
             record_api_call(self.client_id, False, clean_endpoint, method, duration)
-            
+
             if retry_count < self.max_retries:
                 logger.warning(f"Request failed, retrying ({retry_count + 1}/{self.max_retries}): {e}")
                 await asyncio.sleep(2 ** retry_count)
-                return await self._make_request(method, endpoint, params, data, retry_count + 1)
-            
+                return await self._make_request(method, endpoint, params, data, retry_count + 1, auth_retried)
+
             logger.error(f"Request failed after {self.max_retries} retries: {e}")
             return {"error": f"Request failed: {e}"}
-            
+
         except Exception as e:
-            # Record failed API call
+            # Record failed API call (also catches a failed token refresh from
+            # _get_auth_headers() above, now that it runs inside this try)
             duration = time.time() - start_time
             record_api_call(self.client_id, False, clean_endpoint, method, duration)
             logger.error(f"Unexpected error: {e}")

--- a/src/api/api_client.py
+++ b/src/api/api_client.py
@@ -224,6 +224,9 @@ class CharmHealthAPIClient:
             logger.error(f"Token refresh failed while preparing request to {endpoint}: {e}")
             return {"error": f"Token refresh failed: {e}"}
 
+        auth_header = headers.get("Authorization", "")
+        auth_preview = f"{auth_header[:20]}...({len(auth_header)} chars)" if auth_header else "MISSING"
+
         try:
             match method:
                 case "GET":

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -33,6 +33,7 @@ mcp_composite_server.mount(server=task_management_mcp)
 mcp_composite_server.mount(server=communication_mcp)
 mcp_composite_server.mount(server=billing_mcp)
 mcp_composite_server.mount(server=intake_forms_mcp)
+mcp_composite_server.mount(server=referrals_mcp)
 
 @mcp_composite_server.custom_route("/health", methods=["GET"])
 async def health_check(request: Request) -> JSONResponse:

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -58,6 +58,11 @@ from .billing import (
     managePatientBilling
 )
 
+from .referrals import (
+    referrals_mcp,
+    manageReferrals
+)
+
 __all__ = [
     "core_tools_mcp",
     "patient_management_mcp",
@@ -87,5 +92,7 @@ __all__ = [
     "intake_forms_mcp",
     "manageIntakeForms",
     "billing_mcp",
-    "managePatientBilling"
+    "managePatientBilling",
+    "referrals_mcp",
+    "manageReferrals"
 ]

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -387,6 +387,24 @@ DRUG_DOSAGE_UNITS = (
 )
 
 
+def _normalize_drug_enum(value: Optional[str], valid_values: tuple, field_name: str) -> Optional[str]:
+    """Case-fold-match `value` against `valid_values` and return the canonical
+    (correctly-cased) entry. These params used to be typed `Literal[...]`,
+    which made FastMCP's protocol-level schema check reject a title-cased
+    value (e.g. route="Oral") before the function body — and its
+    {"error": ..., "guidance": ...} convention — ever ran. Every value in
+    these tuples is lowercase and models naturally emit title case, so that
+    was the likely path, not a corner case. Doing the validation here
+    instead, case-insensitively, catches the same genuinely-invalid values
+    without breaking the common title-case call."""
+    if value is None:
+        return None
+    for candidate in valid_values:
+        if candidate.casefold() == value.casefold():
+            return candidate
+    raise ValueError(f"{field_name}='{value}' is not a valid CharmHealth catalog value")
+
+
 @clinical_data_mcp.tool
 @with_tool_metrics()
 async def managePatientDrugs(
@@ -408,9 +426,9 @@ async def managePatientDrugs(
     encounter_id: Optional[str] = None,
 
     # Additional supplement fields
-    route: Optional[Literal[DRUG_ROUTES]] = None,
-    dose_form: Optional[Literal[DRUG_DOSE_FORMS]] = None,
-    dosage_unit: Optional[Literal[DRUG_DOSAGE_UNITS]] = None,
+    route: Optional[str] = None,
+    dose_form: Optional[str] = None,
+    dosage_unit: Optional[str] = None,
     quantity: Optional[int] = None,
     intake_type: Optional[str] = None,
     comments: Optional[str] = None,
@@ -591,11 +609,18 @@ async def managePatientDrugs(
                                 "guidance": "A prescription must be tied to the visit it was written during — pass the current encounter_id. To log a medication the patient already takes outside of a visit, use action='add' instead."
                             }
 
+                        try:
+                            route = _normalize_drug_enum(route, DRUG_ROUTES, "route")
+                            dose_form = _normalize_drug_enum(dose_form, DRUG_DOSE_FORMS, "dose_form")
+                            dosage_unit = _normalize_drug_enum(dosage_unit, DRUG_DOSAGE_UNITS, "dosage_unit")
+                        except ValueError as e:
+                            return {"error": str(e), "guidance": "Use one of CharmHealth's fixed catalog values for this field (matching is case-insensitive) — see the tool's <instructions> for examples."}
+
                         med_data = [{
                             "drug_name": drug_name,
                             "is_active": status == "active",
                             "directions": directions,
-                            "dispense": float(quantity) if quantity else 30.0,  # Default 30-day supply
+                            "dispense": float(quantity) if quantity is not None else 30.0,  # Default 30-day supply
                             "refills": refills or "0",
                             "substitute_generic": True,
                             "manufacturing_type": "Manufactured"

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -515,18 +515,23 @@ async def managePatientDrugs(
         client_secret=client_secret
     ) as client:
         try:
-            # Safety check: Review allergies before prescribing
+            # Safety check: Review allergies before prescribing. Built here (once,
+            # before the match) and prepended to the success guidance below —
+            # NOT logged with allergen names, which are PHI. The log line stays
+            # a count only; the actual allergy detail belongs in the tool
+            # response the calling clinician/agent sees, not the server log.
+            allergy_warning = None
             if action in ("add", "prescribe") and check_allergies:
                 allergy_response = await client.get(f"/patients/{patient_id}/allergies")
                 if allergy_response.get("allergies"):
                     allergies = allergy_response["allergies"]
                     if allergies and substance_type == "medication":
-                        allergy_warning = f"WARNING: Patient has {len(allergies)} documented allergies. Review before prescribing: "
-                        allergy_list = [a.get("allergen", "Unknown") for a in allergies[:3]]
-                        allergy_warning += ", ".join(allergy_list)
+                        allergy_names = [a.get("allergen", "Unknown") for a in allergies[:3]]
+                        allergy_warning = f"WARNING: Patient has {len(allergies)} documented allergies: " + ", ".join(allergy_names)
                         if len(allergies) > 3:
                             allergy_warning += f" and {len(allergies) - 3} more"
-                        logger.warning(allergy_warning)
+                        allergy_warning += ". Review before prescribing."
+                        logger.warning(f"managePatientDrugs: {len(allergies)} documented allergies found for patient — see response guidance for detail")
             
             match action:
                 case "list":
@@ -647,7 +652,10 @@ async def managePatientDrugs(
 
                         if response.get("medications"):
                             verb = "prescribed" if action == "prescribe" else "added"
-                            response["guidance"] = f"Medication '{drug_name}' {verb} successfully. Monitor for allergic reactions and drug interactions. Use reviewPatientHistory() to see all current medications."
+                            guidance = f"Medication '{drug_name}' {verb} successfully. Monitor for allergic reactions and drug interactions. Use reviewPatientHistory() to see all current medications."
+                            if allergy_warning:
+                                guidance = f"{allergy_warning} {guidance}"
+                            response["guidance"] = guidance
 
                     elif action == "prescribe":
                         return {
@@ -754,7 +762,7 @@ async def managePatientDrugs(
                         update_data: Dict[str, Any] = {
                             "is_active": current_med.get("is_active", True),
                             "directions": current_med.get("directions", ""),
-                            "dispense": float(current_med.get("dispense") or 30),
+                            "dispense": float(current_med["dispense"]) if current_med.get("dispense") is not None else 30.0,
                             "refills": str(current_med.get("refills", "0")),
                             "substitute_generic": current_med.get("substitute_generic", False),
                             "manufacturing_type": current_med.get("manufacturing_type", "Manufactured"),
@@ -840,7 +848,7 @@ async def managePatientDrugs(
                         discontinue_data: Dict[str, Any] = {
                             "is_active": False,
                             "directions": current_med.get("directions", ""),
-                            "dispense": float(current_med.get("dispense") or 30),
+                            "dispense": float(current_med["dispense"]) if current_med.get("dispense") is not None else 30.0,
                             "refills": str(current_med.get("refills", "0")),
                             "substitute_generic": current_med.get("substitute_generic", False),
                             "manufacturing_type": current_med.get("manufacturing_type", "Manufactured"),

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -699,7 +699,7 @@ async def managePatientDrugs(
                             supplement_data[0]["dose_form"] = dose_form
                         if dosage_unit:
                             supplement_data[0]["dosage_unit"] = dosage_unit
-                        if quantity:
+                        if quantity is not None:
                             supplement_data[0]["quantity"] = int(quantity) if isinstance(quantity, str) else quantity
                         if comments:
                             supplement_data[0]["comments"] = comments

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -369,6 +369,14 @@ DRUG_DOSE_FORMS = (
     "tampon", "tape", "test", "tincture", "wafer",
 )
 
+# "mg/gk" (not "mg/kg") below looks like a transposition typo — it isn't. Re-verified
+# character-for-character against the real backend's drugDosageUnit regex
+# (security-api-charts.xml): the real API genuinely only accepts "mg/gk", not "mg/kg",
+# despite every sibling weight-based unit here (mcg/kg, mEq/kg, units/kg) following the
+# /kg pattern. This looks like a bug in CharmHealth's own enum, not ours — "fixing" it to
+# "mg/kg" here would make this tool reject the value the real API accepts and accept the
+# value it doesn't. Left as "mg/gk" deliberately; don't change without re-confirming
+# against that XML directly, not just eyeballing the pattern mismatch.
 DRUG_DOSAGE_UNITS = (
     "tablet(s)", "capsule(s)", "ml", "application", "spray(s)", "mg", "mcg", "gram", "drop(s)",
     "teaspoon", "tablespoon", "spray", "unit(s)", "IU", "puff(s)", "mg/g", "mg/ml", "mg/gk",

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -14,6 +14,7 @@ from api import CharmHealthAPIClient
 from common.utils import build_params_from_locals, strip_empty_values
 from common.filtering import filter_items
 import logging
+import re
 from telemetry import telemetry, with_tool_metrics
 
 logger = logging.getLogger(__name__)
@@ -433,7 +434,9 @@ async def managePatientDrugs(
     intake_type: Optional[str] = None,
     comments: Optional[str] = None,
     weaning_schedule: Optional[str] = None,
-    
+    substitute_generic: Optional[bool] = None,
+    manufacturing_type: Optional[str] = None,
+
     # Workflow fields
     check_allergies: Optional[bool] = True,
 
@@ -469,10 +472,11 @@ async def managePatientDrugs(
     List filters:
     - status_filter: e.g., status_filter="active"
     - limit: e.g., limit=25
-    For medications: Use clear directions like "Take 1 tablet by mouth twice daily with food"
+    For medications: Use clear directions like "Take 1 tablet by mouth twice daily with food". comments is NOT supported for medications (confirmed live — the API rejects it); it's silently dropped with a WARNING in guidance if provided. Use directions or managePatientNotes() instead.
     For supplements: Provide dosage as integer (e.g., 5) and use strength for units (e.g., "500mg")
     route/dose_form/dosage_unit must be one of CharmHealth's fixed catalog values (e.g. route="oral", dose_form="tablet", dosage_unit="mg") — invalid values are rejected before the API is called.
     quantity sets the dispense amount for a medication (e.g. quantity=90 for "dispense 90 tablets"); defaults to a 30-day supply if omitted.
+    substitute_generic (medication add/prescribe only) defaults to True (pharmacist may substitute a generic equivalent) — pass False for a dispense-as-written / non-substitutable prescription. manufacturing_type defaults to "Manufactured" — pass "Compounded" for a compounded drug (value forwarded as-is, not validated against a catalog).
 
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
@@ -614,6 +618,12 @@ async def managePatientDrugs(
                                 "guidance": "A prescription must be tied to the visit it was written during — pass the current encounter_id. To log a medication the patient already takes outside of a visit, use action='add' instead."
                             }
 
+                        if refills is not None and not re.fullmatch(r"[0-9]{1,2}|PRN|-1", str(refills)):
+                            return {
+                                "error": f"refills='{refills}' is not valid",
+                                "guidance": "refills must be a 1-2 digit number (e.g. '3'), 'PRN', or '-1' (unlimited), per CharmHealth's documented pattern."
+                            }
+
                         try:
                             route = _normalize_drug_enum(route, DRUG_ROUTES, "route")
                             dose_form = _normalize_drug_enum(dose_form, DRUG_DOSE_FORMS, "dose_form")
@@ -627,8 +637,8 @@ async def managePatientDrugs(
                             "directions": directions,
                             "dispense": float(quantity) if quantity is not None else 30.0,  # Default 30-day supply
                             "refills": refills or "0",
-                            "substitute_generic": True,
-                            "manufacturing_type": "Manufactured"
+                            "substitute_generic": True if substitute_generic is None else substitute_generic,
+                            "manufacturing_type": manufacturing_type or "Manufactured"
                         }]
 
                         if strength:
@@ -645,8 +655,18 @@ async def managePatientDrugs(
                             med_data[0]["stop_date"] = end_date.isoformat()
                         if encounter_id:
                             med_data[0]["encounter_id"] = int(encounter_id)
-                        if comments:
-                            med_data[0]["comments"] = comments
+                        # CONFIRMED LIVE (2026-08-27) against the real sandbox: "comments"
+                        # is not a field on this endpoint — fails the ENTIRE add/prescribe
+                        # call with HTTP 400 "Extra key found in JSON" (throwallerrors="true"),
+                        # not a silent drop. "internal_comments" — the field this repo's
+                        # checked-out security-api-charts.xml shows for addEHRMedicationJSON —
+                        # was tried next and ALSO rejected with the identical error against
+                        # this live tenant, so that checkout doesn't match what's actually
+                        # deployed here. Rather than keep guessing field names against a real
+                        # clinical write, comments is dropped entirely for medications (still
+                        # honored for supplements/vitamins, a different endpoint, unaffected)
+                        # — the caller is told rather than hitting a confusing 400.
+                        comments_dropped = bool(comments)
 
                         response = await client.post(f"/patients/{patient_id}/medications", data=med_data)
 
@@ -655,6 +675,13 @@ async def managePatientDrugs(
                             guidance = f"Medication '{drug_name}' {verb} successfully. Monitor for allergic reactions and drug interactions. Use reviewPatientHistory() to see all current medications."
                             if allergy_warning:
                                 guidance = f"{allergy_warning} {guidance}"
+                            if comments_dropped:
+                                guidance += (
+                                    " WARNING: comments was provided but NOT sent — this field "
+                                    "isn't supported on medication add/prescribe (confirmed live; "
+                                    "the API rejects it). Document this detail elsewhere, e.g. "
+                                    "directions or a clinical note via managePatientNotes()."
+                                )
                             response["guidance"] = guidance
 
                     elif action == "prescribe":
@@ -759,10 +786,11 @@ async def managePatientDrugs(
                         # Build payload with all API-required fields, then overlay changes
                         # NOTE: PUT /medications/{id} only accepts: is_active, directions, dispense, refills,
                         # substitute_generic, manufacturing_type, and optional start_date/stop_date/dispense_unit/route/note_to_pharmacy
+                        _dispense = current_med.get("dispense")
                         update_data: Dict[str, Any] = {
                             "is_active": current_med.get("is_active", True),
                             "directions": current_med.get("directions", ""),
-                            "dispense": float(current_med["dispense"]) if current_med.get("dispense") is not None else 30.0,
+                            "dispense": float(_dispense) if _dispense not in (None, "") else 30.0,
                             "refills": str(current_med.get("refills", "0")),
                             "substitute_generic": current_med.get("substitute_generic", False),
                             "manufacturing_type": current_med.get("manufacturing_type", "Manufactured"),
@@ -845,10 +873,11 @@ async def managePatientDrugs(
                                 "guidance": "Use action='list' to verify the record_id exists for this patient."
                             }
 
+                        _dispense = current_med.get("dispense")
                         discontinue_data: Dict[str, Any] = {
                             "is_active": False,
                             "directions": current_med.get("directions", ""),
-                            "dispense": float(current_med["dispense"]) if current_med.get("dispense") is not None else 30.0,
+                            "dispense": float(_dispense) if _dispense not in (None, "") else 30.0,
                             "refills": str(current_med.get("refills", "0")),
                             "substitute_generic": current_med.get("substitute_generic", False),
                             "manufacturing_type": current_med.get("manufacturing_type", "Manufactured"),

--- a/src/tools/clinical_data.py
+++ b/src/tools/clinical_data.py
@@ -336,14 +336,57 @@ async def managePatientVitals(
                 "guidance": f"Vitals {action} failed. Ensure patient_id and encounter_id are valid. Use getPracticeInfo(info_type='vitals') to verify vital naming conventions."
             }
 
+# Real CharmHealth backend enums for route/dose_form/dosage_unit (confirmed against
+# security-api-charts.xml's drugRoute/drugDoseForm/drugDosageUnit regexes) — the real API
+# rejects anything outside these sets, so validating here catches a bad value before the call.
+DRUG_ROUTES = (
+    "buccal", "compounding", "enteral", "extra-amniotic", "implant", "inhalation", "injectable",
+    "intra-amniotic", "intra-articular", "intrabiliary", "intradermal", "intralymphatic",
+    "intramuscular", "intraocular", "intraperitoneal", "intrapleural", "intrathecal",
+    "intratracheal", "intrauteral", "intravenous", "intravesical", "intravitreal", "irrigation",
+    "mucous membrane", "nasal", "ophthalmic", "oral", "oral and injectable", "oral and rectal",
+    "oral and topical", "oral transmucosal", "otic", "parenteral", "percutaneous", "rectal",
+    "spinal", "subcutaneous", "sublingual", "topical", "transdermal", "transurethral", "vaginal",
+)
+
+DRUG_DOSE_FORMS = (
+    "aerosol", "aerosol powder", "aerosol with adapter", "bar", "capsule",
+    "capsule, extended release", "concentrate", "cream", "cream with applicator", "crystal",
+    "delayed release capsule", "delayed release tablet", "device", "disintegrating strip",
+    "dispersion", "dressing", "drops", "elixir", "emulsion", "enema", "enteric coated tablet",
+    "film", "film, extended release", "foam", "foam with applicator", "gas", "gel",
+    "gel forming solution", "gel with applicator", "gelcap", "granule",
+    "granule for reconstitution", "granule, effervescent", "granule, enteric coated",
+    "granule, extended release", "gum", "implant", "injection", "insert", "kit", "liquid",
+    "liquid, extended release", "lotion", "lozenge", "oil", "ointment", "ointment w/applicator",
+    "pad", "paste", "powder", "powder for injection", "powder for injection, extended release",
+    "powder for reconstitution", "powder for reconstitution, delayed release",
+    "powder for reconstitution, extended release", "ring", "shampoo", "soap", "solution",
+    "sponge", "spray", "stick", "suppository", "suspension", "suspension, extended release",
+    "swab", "syrup", "tablet", "tablet, chewable", "tablet, chewable, extended release",
+    "tablet, coated particles", "tablet, disintegrating", "tablet, disintegrating, extended release",
+    "tablet, dispersible", "tablet, effervescent", "tablet, extended release", "tablet, soluble",
+    "tampon", "tape", "test", "tincture", "wafer",
+)
+
+DRUG_DOSAGE_UNITS = (
+    "tablet(s)", "capsule(s)", "ml", "application", "spray(s)", "mg", "mcg", "gram", "drop(s)",
+    "teaspoon", "tablespoon", "spray", "unit(s)", "IU", "puff(s)", "mg/g", "mg/ml", "mg/gk",
+    "mg/m2", "mcg/kg", "mcg/m2", "mEq", "mEq/kg", "Tbsp", "tsp", "inhalation(s)", "neb(s)",
+    "gtt(s)", "supp(s)", "applicatorful", "cartridge(s)", "cloth(s)", "device(s)", "kit(s)", "L",
+    "lozenge(s)", "mask(s)", "ng", "pack(s)", "packet(s)", "pad", "patch(es)", "piece(s)",
+    "ring(s)", "strip(s)", "system(s)", "troche(s)", "vial(s)", "units/kg", "units/m2", "wafer(s)",
+)
+
+
 @clinical_data_mcp.tool
 @with_tool_metrics()
 async def managePatientDrugs(
-    action: Literal["add", "update", "discontinue", "list"],
+    action: Literal["add", "prescribe", "update", "discontinue", "list"],
     patient_id: str,
     substance_type: Literal["medication", "supplement", "vitamin"] = "medication",
     record_id: Optional[str] = None,
-    
+
     # Common drug fields
     drug_name: Optional[str] = None,
     dosage: Optional[str] = None,
@@ -355,11 +398,11 @@ async def managePatientDrugs(
     end_date: Optional[date] = None,
     status: Optional[Literal["active", "inactive"]] = "active",
     encounter_id: Optional[str] = None,
-    
+
     # Additional supplement fields
-    route: Optional[str] = None,
-    dose_form: Optional[str] = None,
-    dosage_unit: Optional[str] = None,
+    route: Optional[Literal[DRUG_ROUTES]] = None,
+    dose_form: Optional[Literal[DRUG_DOSE_FORMS]] = None,
+    dosage_unit: Optional[Literal[DRUG_DOSAGE_UNITS]] = None,
     quantity: Optional[int] = None,
     intake_type: Optional[str] = None,
     comments: Optional[str] = None,
@@ -385,7 +428,8 @@ async def managePatientDrugs(
     
     <instructions>
     Actions:
-    - "add": Prescribe new drug (requires drug_name, directions for medications; drug_name, dosage for supplements)
+    - "add": Log a drug (medication/supplement/vitamin) the patient takes — no encounter tie required. Requires drug_name, directions for medications; drug_name, dosage for supplements.
+    - "prescribe": Same as "add" but for medication only, and REQUIRES encounter_id — this is what actually marks it as a prescription written during a visit rather than a medication-history log entry. Use this, not "add", when a clinician is writing a new prescription during an encounter. There is no lookup action here to discover real catalog values (drug_details_id, generic_drug_id, etc.) — the practice's drug-catalog lookup endpoint (GET /drug/search) requires an OAuth scope this app's credentials don't carry, confirmed via live testing, not fixable from this tool. drug_name is plain free text; a bad/unmatched name may be rejected by the real API as a catalog mismatch — that's expected, not a bug here.
     - "update": Modify existing prescription (requires record_id + fields to change). IMPORTANT: drug name and strength CANNOT be changed via update — use discontinue + add instead. Updatable fields: directions, dispense, refills, status.
     - "discontinue": Stop drug (requires record_id)
     - "list": Show all patient drugs by type (filter by substance_type, optionally filter by status)
@@ -401,6 +445,8 @@ async def managePatientDrugs(
     - limit: e.g., limit=25
     For medications: Use clear directions like "Take 1 tablet by mouth twice daily with food"
     For supplements: Provide dosage as integer (e.g., 5) and use strength for units (e.g., "500mg")
+    route/dose_form/dosage_unit must be one of CharmHealth's fixed catalog values (e.g. route="oral", dose_form="tablet", dosage_unit="mg") — invalid values are rejected before the API is called.
+    quantity sets the dispense amount for a medication (e.g. quantity=90 for "dispense 90 tablets"); defaults to a 30-day supply if omitted.
 
     When required parameters are missing, ask the user to provide the specific values rather than proceeding with defaults or auto-generated values.
     </instructions>
@@ -444,7 +490,7 @@ async def managePatientDrugs(
     ) as client:
         try:
             # Safety check: Review allergies before prescribing
-            if action == "add" and check_allergies:
+            if action in ("add", "prescribe") and check_allergies:
                 allergy_response = await client.get(f"/patients/{patient_id}/allergies")
                 if allergy_response.get("allergies"):
                     allergies = allergy_response["allergies"]
@@ -521,8 +567,8 @@ async def managePatientDrugs(
                             )
                     
                     return strip_empty_values(response)
-                    
-                case "add":
+
+                case "add" | "prescribe":
                     if substance_type == "medication":
                         # Prescription medication
                         required = [drug_name, directions]
@@ -531,19 +577,30 @@ async def managePatientDrugs(
                                 "error": "Missing required fields for medication",
                                 "guidance": "For medications, provide: drug_name and directions. Example: drug_name='Lisinopril 10mg', directions='Take 1 tablet by mouth once daily'. Check allergies first with managePatientAllergies()."
                             }
-                        
+                        if action == "prescribe" and not encounter_id:
+                            return {
+                                "error": "encounter_id required for action='prescribe'",
+                                "guidance": "A prescription must be tied to the visit it was written during — pass the current encounter_id. To log a medication the patient already takes outside of a visit, use action='add' instead."
+                            }
+
                         med_data = [{
                             "drug_name": drug_name,
                             "is_active": status == "active",
                             "directions": directions,
-                            "dispense": 30.0,  # Default 30-day supply
+                            "dispense": float(quantity) if quantity else 30.0,  # Default 30-day supply
                             "refills": refills or "0",
                             "substitute_generic": True,
                             "manufacturing_type": "Manufactured"
                         }]
-                        
+
                         if strength:
                             med_data[0]["strength_description"] = strength
+                        if route:
+                            med_data[0]["route"] = route
+                        if dose_form:
+                            med_data[0]["dose_form"] = dose_form
+                        if dosage_unit:
+                            med_data[0]["dosage_unit"] = dosage_unit
                         if start_date:
                             med_data[0]["start_date"] = start_date.isoformat()
                         if end_date:
@@ -552,12 +609,19 @@ async def managePatientDrugs(
                             med_data[0]["encounter_id"] = int(encounter_id)
                         if comments:
                             med_data[0]["comments"] = comments
-                        
+
                         response = await client.post(f"/patients/{patient_id}/medications", data=med_data)
-                        
+
                         if response.get("medications"):
-                            response["guidance"] = f"Medication '{drug_name}' prescribed successfully. Monitor for allergic reactions and drug interactions. Use reviewPatientHistory() to see all current medications."
-                    
+                            verb = "prescribed" if action == "prescribe" else "added"
+                            response["guidance"] = f"Medication '{drug_name}' {verb} successfully. Monitor for allergic reactions and drug interactions. Use reviewPatientHistory() to see all current medications."
+
+                    elif action == "prescribe":
+                        return {
+                            "error": "action='prescribe' only applies to substance_type='medication'",
+                            "guidance": "Supplements/vitamins aren't prescriptions — use action='add' with substance_type='supplement' or 'vitamin' instead."
+                        }
+
                     else:
                         # Supplement/vitamin
                         required = [drug_name, dosage]

--- a/src/tools/clinical_support.py
+++ b/src/tools/clinical_support.py
@@ -626,7 +626,7 @@ async def managePatientLabs(
 
     # order fields
     facility_id: Optional[str] = None,
-    enc_facility_id: Optional[str] = None,
+    enc_facility_id: Optional[str] = None,  # confirmed against the real API's request XML; not in the published docs
     encounter_id: Optional[str] = None,
     member_id: Optional[str] = None,
     ordered_date: Optional[date] = None,
@@ -634,7 +634,7 @@ async def managePatientLabs(
     lab_notes: Optional[str] = None,
     intra_office_notes: Optional[str] = None,
     specimen_collection_date: Optional[str] = None,
-    specimen_additional_comments: Optional[str] = None,
+    specimen_additional_comments: Optional[str] = None,  # same as enc_facility_id: confirmed via XML, absent from published docs
 
     response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
 

--- a/src/tools/clinical_support.py
+++ b/src/tools/clinical_support.py
@@ -1,16 +1,32 @@
 from fastmcp import FastMCP, Context
 from fastmcp.server.dependencies import get_http_headers
-from typing import Optional, List, Dict, Any, Literal, TypedDict
+from typing import Optional, List, Dict, Any, Literal, TypedDict, Union
 from datetime import date
 from api import CharmHealthAPIClient
 from common.utils import build_params_from_locals, strip_empty_values
 from common.filtering import filter_items
+import json
 import logging
 from telemetry import telemetry, with_tool_metrics
 
 logger = logging.getLogger(__name__)
 
 clinical_support_mcp = FastMCP(name="CharmHealth Clinical Support MCP Server")
+
+
+def _parse_order_tests(value: Optional[Union[str, List[Dict[str, Any]]]]) -> Optional[List[Dict[str, Any]]]:
+    """LLMs sometimes stringify array-typed params — accept either a native list or a JSON-encoded string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            raise ValueError("order_tests must be a JSON array of objects, or a valid JSON-encoded string of one")
+    if not isinstance(value, list):
+        raise ValueError("order_tests must be a list of objects")
+    return value
+
 
 @clinical_support_mcp.tool
 @with_tool_metrics()
@@ -588,12 +604,12 @@ async def managePatientFiles(
 @clinical_support_mcp.tool
 @with_tool_metrics()
 async def managePatientLabs(
-    action: Literal["list", "get_details"],
+    action: Literal["list", "get_details", "order"],
     # Common fields
     patient_id: Optional[str] = None,
     group_id: Optional[str] = None,
     lab_order_id: Optional[str] = None,
-    
+
     # Listing fields
     reviewer_id: Optional[str] = None,
     status: Optional[int] = None,  # 0 or 2
@@ -606,22 +622,53 @@ async def managePatientLabs(
     sort_by: Optional[Literal["DATE", "FULL_NAME"]] = None,
     is_ascending: Optional[bool] = None,
 
+    # order fields
+    facility_id: Optional[str] = None,
+    enc_facility_id: Optional[str] = None,
+    encounter_id: Optional[str] = None,
+    member_id: Optional[str] = None,
+    ordered_date: Optional[date] = None,
+    order_tests: Optional[Union[str, List[Dict[str, Any]]]] = None,
+    lab_notes: Optional[str] = None,
+    intra_office_notes: Optional[str] = None,
+    specimen_collection_date: Optional[str] = None,
+    specimen_additional_comments: Optional[str] = None,
+
     response_format: Optional[Literal["concise", "detailed"]] = None,  # reserved for cortex; no behavior change yet (J13/CH-695)
 
     ctx: Context = None,
 ) -> Dict[str, Any]:
     """
-    Manage patient laboratory results.
-    
+    Manage patient laboratory results and orders.
+
     <usecase>
-    Laboratory results management - list lab results and get detailed reports.
-    Lab results arrive automatically from integrated labs (LabCorp, Quest). For manual entry, use the CharmHealth web portal.
+    Laboratory results management (list results, get detailed reports) and placing
+    new lab orders. Lab results arrive automatically from integrated labs (LabCorp,
+    Quest). For manual entry, use the CharmHealth web portal.
     </usecase>
-    
+
     <instructions>
     Actions:
     - "list": Show lab results with filtering (optionally filter by patient_id, reviewer_id, status, date range)
     - "get_details": Get detailed lab report (requires group_id OR lab_order_id)
+    - "order": Place a new lab order (patient_id required). Requires either
+      encounter_id (derives the ordering provider/facility/date from that
+      encounter) or both member_id and facility_id. order_tests is required and
+      must be non-empty — a list of objects (or a JSON-encoded string of one),
+      each with at least lab_id, lab_name, medical_record_id, and lab_record_id.
+      There is currently no lookup action in this tool to discover those catalog
+      values — the practice's lab/test catalog lookup endpoints
+      (GET /labs/list, GET /lab/{id}/tests/search) require an OAuth scope
+      ("defaults" on the sandbox tenant tested) that this app's credentials don't
+      carry, confirmed via live testing, not fixable from this tool. Whoever calls
+      "order" needs to already know the real catalog values (e.g. looked up
+      manually in the CharmHealth web UI's Settings > Labs) — don't guess or
+      fabricate them; a bad id fails clean, not silently. Optionally: test_name,
+      test_code, test_type, specimen_condition_temperature, specimen_type,
+      z_segment_aoe_map per test. Optional order-level fields: ordered_date
+      (defaults to today, ignored if encounter_id is set), lab_order_id (add these
+      tests to an existing open order instead of creating a new one), lab_notes,
+      intra_office_notes, specimen_collection_date, specimen_additional_comments.
     For detailed results: Use group_id for result groups or lab_order_id for specific orders
     Status codes: 0 for pending, 2 for final results
 
@@ -748,9 +795,67 @@ async def managePatientLabs(
                         response["guidance"] = "Detailed lab results retrieved successfully. Review the test parameters and values for clinical interpretation."
                     else:
                         response["guidance"] = "Lab details not found. Verify the group_id or lab_order_id is correct using action='list' first."
-                    
+
                     return strip_empty_values(response)
-                    
+
+                case "order":
+                    if not patient_id:
+                        return {
+                            "error": "patient_id required for order",
+                            "guidance": "Provide the patient_id to order labs for."
+                        }
+                    if not encounter_id and not (member_id and facility_id):
+                        return {
+                            "error": "Either encounter_id, or both member_id and facility_id, are required for order",
+                            "guidance": "Provide encounter_id to order from within a visit, or member_id + facility_id otherwise."
+                        }
+                    try:
+                        order_tests_parsed = _parse_order_tests(order_tests)
+                    except ValueError as e:
+                        return {"error": str(e), "guidance": "Fix order_tests and try again."}
+                    if not order_tests_parsed:
+                        return {
+                            "error": "order_tests is required and must be non-empty for order",
+                            "guidance": "Provide at least one test with real lab_id/lab_name/medical_record_id/lab_record_id values — e.g. looked up in the CharmHealth web UI's Settings > Labs."
+                        }
+                    missing_fields = [
+                        i for i, t in enumerate(order_tests_parsed)
+                        if not all(t.get(k) for k in ("lab_id", "lab_name", "medical_record_id", "lab_record_id"))
+                    ]
+                    if missing_fields:
+                        return {
+                            "error": f"order_tests[{missing_fields[0]}] is missing one of lab_id/lab_name/medical_record_id/lab_record_id",
+                            "guidance": "Every order_tests item needs all four — use real catalog values, not guessed or fabricated ones."
+                        }
+
+                    order_body: Dict[str, Any] = {
+                        "encounter_id": encounter_id,
+                        "member_id": member_id,
+                        "facility_id": facility_id,
+                        "enc_facility_id": enc_facility_id,
+                        "ordered_date": ordered_date.isoformat() if ordered_date else None,
+                        "lab_order_id": lab_order_id,
+                        "lab_notes": lab_notes,
+                        "intra_office_notes": intra_office_notes,
+                        "specimen_collection_date": specimen_collection_date,
+                        "specimen_additional_comments": specimen_additional_comments,
+                        "order_tests": order_tests_parsed,
+                    }
+                    order_body = {k: v for k, v in order_body.items() if v is not None}
+
+                    response = await client.post(f"/patients/{patient_id}/labs/order", data=order_body)
+                    if isinstance(response, dict) and response.get("error"):
+                        return {
+                            "error": response["error"],
+                            "guidance": "Could not place the lab order. Verify patient_id, the encounter/member/facility fields, and that every order_tests item has real catalog values."
+                        }
+                    # Real response is a bare JSON array of created/updated LAB_ORDER_ID
+                    # values, wrapped under "lab_orders_list" — confirmed against
+                    # LabsAPIBeanImpl.addLabOrder's OutputXMLFormat.
+                    order_ids = response if isinstance(response, list) else (response or {}).get("lab_orders_list") or []
+                    result = {"lab_order_ids": order_ids, "guidance": "Lab order placed." if order_ids else "Lab order call succeeded but returned no order IDs — verify against action='list'."}
+                    return strip_empty_values(result)
+
         except Exception as e:
             logger.error(f"Error in managePatientLabs: {e}")
             return {

--- a/src/tools/clinical_support.py
+++ b/src/tools/clinical_support.py
@@ -25,6 +25,8 @@ def _parse_order_tests(value: Optional[Union[str, List[Dict[str, Any]]]]) -> Opt
             raise ValueError("order_tests must be a JSON array of objects, or a valid JSON-encoded string of one")
     if not isinstance(value, list):
         raise ValueError("order_tests must be a list of objects")
+    if not all(isinstance(item, dict) for item in value):
+        raise ValueError("order_tests must be a list of objects — each item must be a JSON object with lab_id/lab_name/medical_record_id/lab_record_id, not a bare string or number")
     return value
 
 

--- a/src/tools/referrals.py
+++ b/src/tools/referrals.py
@@ -541,7 +541,10 @@ async def manageReferrals(
                     # "create"/"respond" accept "Completed" on direction="in", which
                     # "update" does not either) — see REFERRAL_STATUS_SETS. Re-checked
                     # after the merge below, not assumed valid just because some prior
-                    # write accepted it.
+                    # write accepted it. The two directions handle an invalid *merged*
+                    # value differently there — "out" fails closed (the field isn't
+                    # safe to omit server-side), "in" drops it (safe to omit) — see the
+                    # comment at that check.
                     status_error = _validate_response_status(direction, "update", response_status)
                     if status_error:
                         return status_error
@@ -585,16 +588,39 @@ async def manageReferrals(
                     if referral_reason is None:
                         referral_reason = existing.get("referral_reason")
                     if response_status is None:
-                        response_status = existing.get("response_status")
-                        # The merged-in value may be valid for whatever action last set
-                        # it but not for "update"'s own narrower set (see the comment on
-                        # the pre-merge validation above). Drop it rather than send a
-                        # value guaranteed to be rejected — the caller never asked to
-                        # change this field, so silently omitting it (leaving it as
-                        # whatever the backend already has) is correct; sending it would
-                        # fail the whole update over a field the caller didn't touch.
-                        if response_status is not None and response_status not in REFERRAL_STATUS_SETS[direction]["update"]:
-                            response_status = None
+                        merged_status = existing.get("response_status")
+                        if merged_status is not None and merged_status not in REFERRAL_STATUS_SETS[direction]["update"]:
+                            # The merged-in value is valid for whatever action last set
+                            # it (e.g. "respond") but not for "update"'s own narrower
+                            # set (see the comment on the pre-merge validation above).
+                            #
+                            # direction="out": CONFIRMED against ReferralBeanImpl.
+                            # updateReferralOut — resStatus is read from the request
+                            # body under a null check, but row.set("RESPONSE_STATUS",
+                            # resStatus) runs UNCONDITIONALLY, outside that check. Key
+                            # absent means resStatus stays null and the column gets
+                            # explicitly nulled — the same shape as the
+                            # TO_INTERNAL_MEMBER_ID wipe this whole merge exists to
+                            # prevent. Omitting it here would silently clear a field
+                            # the caller never touched, worse than the 400 this
+                            # replaced. Fail instead and let the caller decide.
+                            if direction == "out":
+                                return {
+                                    "error": f"Stored response_status={merged_status!r} is not valid for direction='out' update",
+                                    "guidance": (
+                                        f"This referral's response_status was set by a different action (e.g. 'respond') and "
+                                        f"can't be carried through 'update' as-is — the backend clears the column when "
+                                        f"response_status is left out of an update request, it does not leave it untouched. "
+                                        f"Provide an explicit response_status from {REFERRAL_STATUS_SETS[direction]['update']} "
+                                        f"to keep or change it as part of this call."
+                                    )
+                                }
+                            # direction="in": updateReferralIn has this same row.set
+                            # line commented out server-side — the field is dead here,
+                            # so omitting an invalid merged value is safe (the stored
+                            # value is left untouched either way), unlike "out".
+                            merged_status = None
+                        response_status = merged_status
                     if referral_date is None and existing.get("referral_date"):
                         try:
                             referral_date = date.fromisoformat(str(existing["referral_date"])[:10])

--- a/src/tools/referrals.py
+++ b/src/tools/referrals.py
@@ -429,6 +429,16 @@ async def manageReferrals(
                     # silently always None before this fix, hence "ref_id=None" in every
                     # prior create's guidance message. Unwrap to get the real ref_id.
                     created = _unwrap_mutation_response(response)
+                    # _unwrap_mutation_response falls back to returning `response`
+                    # unchanged when it isn't shaped as expected — which itself falls
+                    # back to whatever the API sent if that wasn't a dict either (e.g.
+                    # an array). Guard here so a create that actually succeeded doesn't
+                    # get reported as a failure just because we can't parse ref_id out
+                    # of it — that false failure is worse than a missing ref_id, since
+                    # the natural response to "Could not create" is a retry, which
+                    # would duplicate the referral that was, in fact, created.
+                    if not isinstance(created, dict):
+                        created = {"raw_response": created}
                     ref_id = created.get("ref_id") or created.get("ref_in_id")
                     # Don't trust this response's own party-member fields (from_member/
                     # to_internal_member/etc.) — CONFIRMED LIVE they can echo back a
@@ -494,6 +504,7 @@ async def manageReferrals(
                     # the backend's own entity-format config, not guessed.
                     wrapper_key = "referralout" if direction == "out" else "referralin"
                     referrals = response if isinstance(response, list) else response.get(wrapper_key, [])
+                    referrals = [_mask_notes_pointer(r) for r in referrals]
                     result: Dict[str, Any] = {"referrals": referrals, "total_count": len(referrals)}
                     result["guidance"] = (
                         f"Found {len(referrals)} referral(s)." if referrals
@@ -515,7 +526,7 @@ async def manageReferrals(
                         }
                     result = _unwrap_get_response(response, direction)
                     result["guidance"] = "Referral retrieved."
-                    return strip_empty_values(result)
+                    return strip_empty_values(_mask_notes_pointer(result))
 
                 case "update":
                     if not referral_id:
@@ -711,6 +722,7 @@ async def manageReferrals(
                         "image_ids": image_ids,
                         "growth_ids": growth_ids,
                     }
+                    diagnoses_dropped_for_out = direction == "out" and diagnoses_parsed
                     if direction == "in":
                         respond_body["diagnoses"] = diagnoses_parsed
                     respond_body = {k: v for k, v in respond_body.items() if v is not None}
@@ -761,6 +773,13 @@ async def manageReferrals(
                     else:
                         result = _unwrap_mutation_response(response)
                     guidance = "Response recorded."
+                    if diagnoses_dropped_for_out:
+                        guidance += (
+                            " WARNING: diagnoses was provided but NOT sent — direction='out' "
+                            "responses don't support a diagnoses field (the API schema has no "
+                            "such key for this direction; only direction='in' does). Nothing "
+                            "downstream received these diagnoses from this call."
+                        )
                     if direction == "in":
                         # Confirmed in ReferralBeanImpl.addReferralInResponse: if this "in"
                         # record is linked to an internal outbound referral (REF_OUT_ID set),

--- a/src/tools/referrals.py
+++ b/src/tools/referrals.py
@@ -1,0 +1,767 @@
+from fastmcp import FastMCP, Context
+from fastmcp.server.dependencies import get_http_headers
+from typing import Optional, List, Dict, Any, Literal, Union
+from datetime import date
+from api import CharmHealthAPIClient
+from common.utils import strip_empty_values
+import json
+import logging
+from telemetry import telemetry, with_tool_metrics
+
+logger = logging.getLogger(__name__)
+
+referrals_mcp = FastMCP(name="CharmHealth Referrals MCP Server")
+
+
+def _unwrap_get_response(response: Any, direction: str) -> Dict[str, Any]:
+    """
+    CONFIRMED LIVE (2026-08-11): GET /referrals/{direction}/{id} does NOT return
+    the referral's fields flat at the top level — it wraps them one level down
+    under a key matching the direction ("referral_out"/"referral_in"), alongside
+    "code"/"message":
+        {"code": "0", "message": "success", "referral_out": {...actual fields...}}
+    Every earlier version of this tool assumed a flat shape (matching
+    ReferralOutResponseNew/ReferralInResponseNew's XML definition, which is a
+    non-array entity — wrongly inferred to mean "serializes flat"). This silently
+    broke `update`'s fetch-then-merge: `existing.get("facility_id")` always
+    returned None because `facility_id` was actually at `existing["referral_out"]
+    ["facility_id"]`, so the merge never worked and every field it claimed to
+    backfill had to be supplied explicitly — exactly the "undocumented required
+    fields" behavior reported live, repeatedly, and previously misdiagnosed as a
+    stale MCP server rather than a real bug in this unwrapping.
+    """
+    if not isinstance(response, dict):
+        return response
+    key = "referral_out" if direction == "out" else "referral_in"
+    inner = response.get(key)
+    return inner if isinstance(inner, dict) else response
+
+
+def _unwrap_mutation_response(response: Any) -> Dict[str, Any]:
+    """
+    CONFIRMED LIVE (2026-08-11): create/update/respond's response is wrapped
+    TWO levels deep, not flat — {"code", "message", "referrals": {"referrals":
+    {...actual fields...}}} — confirmed against both ReferralOutResponse's and
+    ReferralInResponse's real XML definition (<referrals name="...">
+    <referrals table="...">...</referrals></referrals>, a double-nested tag of
+    the same name) and a live create/update call. `ref_id` extraction
+    (`response.get("ref_id")`) was silently always None before this fix.
+
+    Separately and more importantly: this response's own from_member/
+    to_internal_member/to_member/from_internal_member/from_external_member
+    fields are NOT reliable confirmation of what was persisted — confirmed live
+    by sending from_member=...117 and getting back "...110" in this same
+    response, then immediately re-fetching via GET (whose fields ARE reliable,
+    per _unwrap_get_response) and finding ...117 correctly stored. Callers of
+    this unwrap function should still do a follow-up GET for anything beyond
+    the bare ref_id — don't trust the unwrapped party-member fields either.
+    """
+    if not isinstance(response, dict):
+        return response
+    outer = response.get("referrals")
+    if isinstance(outer, dict):
+        inner = outer.get("referrals")
+        if isinstance(inner, dict):
+            return inner
+    return response
+
+
+def _mask_notes_pointer(resp: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    REFERRAL_NOTES and RESPONSE_NOTES are both stored server-side as raw DFS
+    file-pointer strings, not the text that was sent. Confirmed live for
+    referral_notes (garbled values like
+    "1786019884879_referral.html!@>NN1:-4152206861348658358"); confirmed for
+    response_notes by reading the identical file-storage code path in
+    ReferralBeanImpl.addReferralResponse/addReferralInResponse — same write
+    pattern, same garbling on read. Reading either back as real text requires
+    the separate GET .../notes sub-resource, which this tool doesn't implement
+    yet. Strip both rather than hand an LLM a string that looks like content
+    but isn't.
+    """
+    if not isinstance(resp, dict):
+        return resp
+    masked_any = False
+    for field in ("referral_notes", "response_notes"):
+        if resp.get(field):
+            resp[field] = None
+            masked_any = True
+    if masked_any:
+        resp["_notes_fields_note"] = (
+            "referral_notes/response_notes omitted from this response — the API returns "
+            "an internal file pointer here, not the text you sent. Reading actual note "
+            "content requires the /notes sub-resource, not yet supported by this tool."
+        )
+    return resp
+
+
+def _parse_list_of_dicts(value: Optional[Union[str, List[Dict[str, Any]]]], field_name: str) -> Optional[List[Dict[str, Any]]]:
+    """LLMs sometimes stringify array-typed params — accept either a native list or a JSON-encoded string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            raise ValueError(f"{field_name} must be a JSON array of objects, or a valid JSON-encoded string of one")
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list of objects")
+    return value
+
+
+# response_status's valid set genuinely differs per (direction, action) — confirmed
+# directly against security-api-referral.xml's <jsontemplate> regexes, each checked
+# individually rather than assumed consistent (they aren't, even within one
+# direction — see REFERRAL_STATUS_SETS["out"]["update"] vs. ["out"]["respond"]).
+# Kept as plain str (not Literal) in the function signature because a single
+# Literal type can't vary by direction/action — validated here instead, with an
+# error that actually lists the valid options rather than passing through the
+# real API's generic "Invalid value passed for response_status" 400.
+REFERRAL_STATUS_SETS: Dict[str, Dict[str, tuple]] = {
+    "out": {
+        "create": ("Pending", "Received", "Reviewed"),
+        "update": ("Pending", "Received", "Reviewed"),
+        "respond": ("Pending", "To Be Reviewed", "Reviewed"),
+        "list": ("Pending", "Reviewed", "To Be Reviewed"),
+    },
+    "in": {
+        "create": ("Pending", "Completed"),
+        # NOT "Pending"|"Completed" like create/respond — updateReferralInJSON's
+        # own schema declares this set; inconsistent within the real API itself,
+        # documented as found rather than smoothed over.
+        "update": ("Pending", "Received", "Reviewed"),
+        "respond": ("Pending", "Completed"),
+        "list": ("Pending", "Completed"),
+    },
+}
+
+
+def _validate_response_status(direction: str, action: str, response_status: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Returns an error dict if response_status is set but invalid for this
+    (direction, action); None if absent or valid."""
+    if response_status is None:
+        return None
+    valid = REFERRAL_STATUS_SETS[direction][action]
+    if response_status not in valid:
+        return {
+            "error": f"response_status={response_status!r} is not valid for direction={direction!r} action={action!r}",
+            "guidance": f"Valid values here are: {', '.join(valid)}."
+        }
+    return None
+
+
+@referrals_mcp.tool
+@with_tool_metrics()
+async def manageReferrals(
+    action: Literal["create", "list", "get", "update", "respond"],
+    direction: Literal["out", "in"],
+
+    referral_id: Optional[str] = None,
+    patient_id: Optional[str] = None,
+    facility_id: Optional[str] = None,
+    referral_date: Optional[date] = None,
+    response_date: Optional[date] = None,
+
+    # direction="out": referring this practice's patient TO another provider
+    from_member: Optional[str] = None,
+    to_external_member: Optional[str] = None,
+    to_internal_member: Optional[str] = None,
+
+    # direction="in": tracking a referral received FROM another provider
+    to_member: Optional[str] = None,
+    from_external_member: Optional[str] = None,
+    from_internal_member: Optional[str] = None,
+
+    priority: Optional[Literal["Urgent", "Normal"]] = None,
+    referral_reason: Optional[str] = None,
+    referral_notes: Optional[str] = None,
+    response_notes: Optional[str] = None,
+    response_status: Optional[str] = None,
+    encounter_id: Optional[str] = None,
+
+    diagnoses: Optional[Union[str, List[Dict[str, Any]]]] = None,
+    insurance: Optional[Union[str, List[Dict[str, Any]]]] = None,
+
+    chartnote_ids: Optional[str] = None,
+    lab_ids: Optional[str] = None,
+    document_ids: Optional[str] = None,
+    image_ids: Optional[str] = None,
+    growth_ids: Optional[str] = None,
+
+    page: Optional[int] = None,
+    per_page: Optional[int] = None,
+
+    ctx: Context = None,
+) -> Dict[str, Any]:
+    """
+    Manage patient referrals — referring a patient out to a specialist, or tracking
+    a referral received from another provider.
+
+    <usecase>
+    Referral coordination: create/list/get/update referrals in either direction, and
+    record a response to one (e.g. the specialist's findings, or your own review of an
+    incoming referral). E-signing and file attachments are not covered by this tool
+    yet. Creating a referral is NOT the same as sending it — see the transmission
+    note below.
+    </usecase>
+
+    <instructions>
+    direction picks which referral family this call operates on — the two are separate
+    records on the backend, not two views of the same thing:
+    - "out": referring this practice's patient TO another provider (a specialist).
+      Party fields: from_member (the referring provider, at this practice, required on
+      create) plus exactly one of to_external_member (outside specialist) or
+      to_internal_member (in-network provider) — required on create.
+    - "in": tracking a referral this practice received FROM another provider.
+      Party fields: to_member (the receiving provider, at this practice, required on
+      create) plus exactly one of from_external_member or from_internal_member —
+      required on create.
+
+    Actions:
+    - "create": New referral. Requires facility_id, referral_date, and the direction's
+      required party fields above.
+    - "list": List referrals for this direction. Optional filters: patient_id,
+      facility_id, response_status, page, per_page, plus the direction's party-id
+      fields (from_member/to_internal_member/to_external_member for "out";
+      to_member/from_internal_member/from_external_member for "in") to filter by
+      provider.
+    - "get": Fetch a single referral (referral_id required).
+    - "update": Update an existing referral (referral_id required). The real backend
+      does a FULL ROW OVERWRITE, not a partial patch — any field you omit gets wiped
+      to null/empty server-side. This tool fetches the existing referral first and
+      merges your fields on top of it, so omitting facility_id/patient_id/priority/
+      referral_reason/response_status/referral_date/the party fields will correctly
+      preserve their current values. facility_id, from_member (or to_member for
+      "in"), and patient_id are still hard-required by the backend either way —
+      the merge fills them from the existing record if you don't pass them.
+      NOT covered by this merge (still wiped if omitted, because "get" doesn't
+      return them or their round-trip shape isn't confirmed): referral_notes,
+      response_notes, related_encounter_id (encounter_id), diagnoses, insurance,
+      and the attachment-linking *_ids fields. Pass these explicitly every time
+      you want them to survive an update.
+      direction="in" additionally cannot change facility_id or its party fields
+      via update at all — the backend ignores them for "in" regardless.
+    - "respond": Record a response to a referral (referral_id AND facility_id both
+      required — facility_id is enforced by the API's request schema even though
+      the response-recording logic itself never uses it, so don't assume it's
+      optional just because "get"/"update" treat it as re-derivable). Beyond that,
+      provide at least one of response_date, response_notes, response_status, or
+      (direction="in" only) diagnoses. chartnote_ids/lab_ids/document_ids/
+      image_ids/growth_ids link supporting records to the response, same
+      comma-separated-id convention as create/update. direction="out" does NOT
+      accept diagnoses — the API's schema has no such field for it; only
+      direction="in" writes a response diagnosis list.
+      QUIRK (direction="in" only): if this incoming referral is linked to an
+      internal outbound referral record (i.e. it was auto-created when someone at
+      this practice referred a patient to an internal provider), responding here
+      ALSO cascades response_date/response_notes onto that linked "out" record and
+      force-sets ITS response_status to the literal string "To Be Reviewed" —
+      regardless of the response_status you passed on this call. Real backend
+      behavior, not a bug in this tool.
+      Both directions auto-notify the original referring provider in-app when a
+      response is recorded (unless they're the one responding).
+
+    KNOWN LIMITATION — external-provider referrals: to_external_member (direction="out")
+    and from_external_member (direction="in") must be a real, pre-existing numeric ID
+    already registered in this practice's referral directory. There is no tool here (or
+    any REST endpoint found in the backend) to look up or register a new external
+    provider — passing a name or an arbitrary/unregistered number fails with
+    "zf.api.inavalid.id.provided". Only to_internal_member/from_internal_member
+    (in-network providers, already known to this practice) are reliably usable end to
+    end today.
+
+    KNOWN LIMITATION — creating a referral does not send it, for external referrals.
+    An internal referral (to_internal_member/from_internal_member) auto-notifies the
+    receiving provider in-app at creation time — nothing more to do. An EXTERNAL
+    referral notifies no one on creation; the real EHR requires a separate manual
+    "Transmit" step (fax, or Direct Secure Messaging via an accredited HISP) that
+    exists only in the old UI layer and has no REST API equivalent at all — there is
+    no way for this tool (or any API caller) to actually send an external referral to
+    the specialist. Combined with the directory-lookup gap above, external referrals
+    are effectively metadata-only today: don't tell a user or clinician an external
+    referral has been "sent" just because create succeeded.
+
+    response_status valid values — CONFIRMED PER (direction, action) from the API's
+    own request schemas (security-api-referral.xml jsontemplates), each checked
+    individually rather than assumed consistent — they are NOT consistent, even
+    within the same direction, even though every action writes the same
+    RESPONSE_STATUS column:
+    - direction="out", action="create": "Pending" | "Received" | "Reviewed".
+    - direction="out", action="update": "Pending" | "Received" | "Reviewed" (same as create).
+    - direction="out", action="respond": "Pending" | "To Be Reviewed" | "Reviewed"
+      — "Received" is NOT valid here, "To Be Reviewed" IS (the inverse of
+      create/update's set on those two values).
+    - direction="out", "list" filter: "Pending" | "Reviewed" | "To Be Reviewed".
+    - direction="in", action="create": "Pending" | "Completed".
+    - direction="in", action="update": "Pending" | "Received" | "Reviewed" — NOT
+      "Completed". Surprising given create/respond both use Pending|Completed for
+      "in", but this is what the API's own updateReferralInJSON schema declares;
+      documented as found, not smoothed over for consistency.
+    - direction="in", action="respond": "Pending" | "Completed".
+
+    diagnoses / insurance accept either a native JSON array of objects or a
+    JSON-encoded string of one, e.g. diagnoses=[{"name": "...", "code": "...", "id": "..."}]
+    or insurance=[{"name": "...", "id": "..."}].
+
+    chartnote_ids / lab_ids / document_ids / image_ids / growth_ids are comma-separated
+    id strings (e.g. "123,456"), matching the real API's expected format.
+
+    When required parameters are missing, ask the user to provide the specific values
+    rather than proceeding with defaults or auto-generated values.
+    </instructions>
+    """
+    access_token = None
+    refresh_token = None
+    base_url = None
+    token_url = None
+    client_secret = None
+    accounts_server = None
+
+    try:
+        headers = get_http_headers()
+        access_token = headers.get('x-user-access-token')
+        refresh_token = headers.get('x-user-refresh-token')
+        base_url = headers.get('x-charmhealth-base-url')
+        token_url = headers.get('x-charmhealth-token-url')
+        client_secret = headers.get('x-charmhealth-client-secret')
+        accounts_server = headers.get('x-charmhealth-accounts-server')
+
+        if accounts_server:
+            token_url = f"{accounts_server.rstrip('/')}/oauth/v2/token"
+
+        if base_url and not base_url.endswith('/api/ehr/v1'):
+            base_url = base_url.rstrip('/') + '/api/ehr/v1'
+
+        if access_token:
+            logger.info("manageReferrals using user credentials")
+        else:
+            logger.info("manageReferrals using environment variable credentials")
+    except Exception as e:
+        logger.debug(f"Could not get HTTP headers (might be stdio mode): {e}")
+
+    async with CharmHealthAPIClient(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        base_url=base_url,
+        token_url=token_url,
+        client_secret=client_secret
+    ) as client:
+        try:
+            base_path = f"/referrals/{direction}"
+
+            try:
+                diagnoses_parsed = _parse_list_of_dicts(diagnoses, "diagnoses")
+                insurance_parsed = _parse_list_of_dicts(insurance, "insurance")
+            except ValueError as e:
+                return {"error": str(e), "guidance": "Fix the field and try again."}
+
+            def build_body() -> Dict[str, Any]:
+                body: Dict[str, Any] = {
+                    "facility_id": facility_id,
+                    "referral_date": referral_date.isoformat() if referral_date else None,
+                    "patient_id": patient_id,
+                    "priority": priority,
+                    "referral_reason": referral_reason,
+                    "referral_notes": referral_notes,
+                    "response_notes": response_notes,
+                    "response_status": response_status,
+                    "encounter_id": encounter_id,
+                    "diagnoses": diagnoses_parsed,
+                    "insurance": insurance_parsed,
+                    "chartnote_ids": chartnote_ids,
+                    "lab_ids": lab_ids,
+                    "document_ids": document_ids,
+                    "image_ids": image_ids,
+                    "growth_ids": growth_ids,
+                }
+                if direction == "out":
+                    body["from_member"] = from_member
+                    body["to_external_member"] = to_external_member
+                    body["to_internal_member"] = to_internal_member
+                else:
+                    body["to_member"] = to_member
+                    body["from_external_member"] = from_external_member
+                    body["from_internal_member"] = from_internal_member
+                return {k: v for k, v in body.items() if v is not None}
+
+            match action:
+
+                case "create":
+                    status_error = _validate_response_status(direction, "create", response_status)
+                    if status_error:
+                        return status_error
+                    if not facility_id or not referral_date:
+                        return {
+                            "error": "facility_id and referral_date are required to create a referral",
+                            "guidance": "Provide facility_id and referral_date (YYYY-MM-DD)."
+                        }
+                    if direction == "out":
+                        if not from_member:
+                            return {
+                                "error": "from_member is required for direction='out'",
+                                "guidance": "Provide from_member (the referring provider at this practice)."
+                            }
+                        if not to_external_member and not to_internal_member:
+                            return {
+                                "error": "One of to_external_member or to_internal_member is required for direction='out'",
+                                "guidance": "Provide the receiving provider — to_external_member for an outside specialist, to_internal_member for someone in-network."
+                            }
+                    else:
+                        if not to_member:
+                            return {
+                                "error": "to_member is required for direction='in'",
+                                "guidance": "Provide to_member (the receiving provider at this practice)."
+                            }
+                        if not from_external_member and not from_internal_member:
+                            return {
+                                "error": "One of from_external_member or from_internal_member is required for direction='in'",
+                                "guidance": "Provide the referring provider — from_external_member for an outside provider, from_internal_member for someone in-network."
+                            }
+
+                    response = await client.post(base_path, data=build_body())
+                    if isinstance(response, dict) and response.get("error"):
+                        return {
+                            "error": response["error"],
+                            "guidance": "Could not create the referral. Verify facility_id, referral_date, and the required party fields for this direction."
+                        }
+                    # CONFIRMED LIVE (2026-08-11): this response is double-nested
+                    # ({"referrals":{"referrals":{...}}}) — response.get("ref_id") was
+                    # silently always None before this fix, hence "ref_id=None" in every
+                    # prior create's guidance message. Unwrap to get the real ref_id.
+                    created = _unwrap_mutation_response(response)
+                    ref_id = created.get("ref_id") or created.get("ref_in_id")
+                    # Don't trust this response's own party-member fields (from_member/
+                    # to_internal_member/etc.) — CONFIRMED LIVE they can echo back a
+                    # different value than what was actually persisted (sent ...117, this
+                    # response said ...110, a follow-up GET correctly showed ...117 stored).
+                    # Re-fetch instead of returning `created` directly.
+                    if ref_id:
+                        verify_response = await client.get(f"{base_path}/{ref_id}")
+                        if isinstance(verify_response, dict) and not verify_response.get("error"):
+                            created = _unwrap_get_response(verify_response, direction)
+                    created["guidance"] = (
+                        f"Referral created (ref_id={ref_id}). Use 'get' with this referral_id to check status, "
+                        "or 'update' to add diagnoses/notes later."
+                    )
+                    return strip_empty_values(_mask_notes_pointer(created))
+
+                case "list":
+                    params: Dict[str, Any] = {}
+                    if patient_id:
+                        params["patient_id"] = patient_id
+                    if facility_id:
+                        params["facility_id"] = facility_id
+                    if response_status:
+                        params["response_status"] = response_status
+                    if page:
+                        params["page"] = page
+                    if per_page:
+                        params["per_page"] = per_page
+                    # Confirmed directly against the backend's criteria-resolver code
+                    # (CharmTemplateHandler: REFERRAL_FROM_MEMBER_CR / REFERRAL_TO_MEMBER_CR
+                    # for "out"; REFERRAL_IN_TO_MEMBER_CR / REFERRAL_IN_FROM_MEMBER_CR for "in") —
+                    # both directions' filter param names below are real, not guessed.
+                    # NOTE: facility_id has no effect on direction="in" — GetReferralInListSQ's
+                    # WHERE clause doesn't include a facility criteria macro at all, unlike "out".
+                    if direction == "out":
+                        if from_member:
+                            params["from_member_id"] = from_member
+                        if to_internal_member:
+                            params["to_internal_member_id"] = to_internal_member
+                        if to_external_member:
+                            params["to_external_member_id"] = to_external_member
+                    else:
+                        if to_member:
+                            params["to_member_id"] = to_member
+                        if from_internal_member:
+                            params["from_internal_member_id"] = from_internal_member
+                        if from_external_member:
+                            params["from_external_member_id"] = from_external_member
+
+                    response = await client.get(base_path, params=params)
+                    if isinstance(response, dict) and response.get("error"):
+                        return {
+                            "error": response["error"],
+                            "guidance": "Could not list referrals. Verify the filters provided."
+                        }
+                    # The real response wraps the array under a key matching the outer XML
+                    # element name in EntityXMLFormat.xml — "referralout" for direction="out"
+                    # (<referralout name="ReferralsOutResponseNew" classAttr="array">) and
+                    # "referralin" for direction="in" — NOT "referrals". Confirmed by reading
+                    # the backend's own entity-format config, not guessed.
+                    wrapper_key = "referralout" if direction == "out" else "referralin"
+                    referrals = response if isinstance(response, list) else response.get(wrapper_key, [])
+                    result: Dict[str, Any] = {"referrals": referrals, "total_count": len(referrals)}
+                    result["guidance"] = (
+                        f"Found {len(referrals)} referral(s)." if referrals
+                        else "No referrals found matching the filters."
+                    )
+                    return strip_empty_values(result)
+
+                case "get":
+                    if not referral_id:
+                        return {
+                            "error": "referral_id required for get",
+                            "guidance": "Provide the referral_id to fetch."
+                        }
+                    response = await client.get(f"{base_path}/{referral_id}")
+                    if isinstance(response, dict) and response.get("error"):
+                        return {
+                            "error": response["error"],
+                            "guidance": "Could not retrieve the referral. Verify referral_id and direction are correct."
+                        }
+                    result = _unwrap_get_response(response, direction)
+                    result["guidance"] = "Referral retrieved."
+                    return strip_empty_values(result)
+
+                case "update":
+                    if not referral_id:
+                        return {
+                            "error": "referral_id required for update",
+                            "guidance": "Provide the referral_id to update."
+                        }
+                    # Validate before the merge below — a value merged in from the
+                    # existing record is already valid by definition (it was accepted on
+                    # a prior write), only a caller-supplied value needs checking here.
+                    status_error = _validate_response_status(direction, "update", response_status)
+                    if status_error:
+                        return status_error
+
+                    # The real backend does a FULL ROW OVERWRITE on update, not a partial
+                    # patch — confirmed live: omitting to_internal_member on an update wiped
+                    # it to null, which was what triggered deleteReferralOut's NPE bug (the
+                    # reason "delete" isn't exposed by this tool at all — see the docstring).
+                    # Fetch the existing record and merge caller-supplied fields on top of it
+                    # so a call that only means to change e.g. priority doesn't silently
+                    # blank everything else.
+                    #
+                    # IMPORTANT — this merge is only as complete as what "get" returns.
+                    # ReferralOutResponseNew/ReferralInResponseNew (the "get" shape) does NOT
+                    # include referral_notes, response_notes, or related_encounter_id at all,
+                    # and diagnoses/insurance's stored round-trip shape (JSON string vs. parsed
+                    # array) isn't confirmed — so those fields are NOT safely preserved here.
+                    # If you're not explicitly setting one of those on this call, treat it as
+                    # being wiped, same as before this fix.
+                    existing_raw = await client.get(f"{base_path}/{referral_id}")
+                    if isinstance(existing_raw, dict) and existing_raw.get("error"):
+                        return {
+                            "error": existing_raw["error"],
+                            "guidance": "Could not fetch the existing referral to merge before updating. Verify referral_id and direction are correct."
+                        }
+                    # MUST unwrap — CONFIRMED LIVE this response nests fields under
+                    # "referral_out"/"referral_in", not flat. Without this, every
+                    # existing.get(...) below silently returns None and the merge never
+                    # actually merges anything — this was the real cause of "update
+                    # requires undocumented fields", not a stale server as first assumed.
+                    existing = _unwrap_get_response(existing_raw, direction)
+                    if not isinstance(existing, dict):
+                        existing = {}
+
+                    if facility_id is None:
+                        facility_id = existing.get("facility_id")
+                    if patient_id is None:
+                        patient_id = existing.get("patient_id")
+                    if priority is None:
+                        priority = existing.get("priority")
+                    if referral_reason is None:
+                        referral_reason = existing.get("referral_reason")
+                    if response_status is None:
+                        response_status = existing.get("response_status")
+                    if referral_date is None and existing.get("referral_date"):
+                        try:
+                            referral_date = date.fromisoformat(str(existing["referral_date"])[:10])
+                        except ValueError:
+                            pass  # leave referral_date unset rather than crash on an unexpected format
+
+                    if direction == "out":
+                        if from_member is None:
+                            from_member = existing.get("from_member_id")
+                        if to_external_member is None:
+                            to_external_member = existing.get("to_external_member_id")
+                        if to_internal_member is None:
+                            to_internal_member = existing.get("to_internal_member_id")
+                    else:
+                        if to_member is None:
+                            to_member = existing.get("to_member_id")
+                        if from_external_member is None:
+                            from_external_member = existing.get("from_external_member_id")
+                        if from_internal_member is None:
+                            from_internal_member = existing.get("from_internal_member_id")
+
+                    # Two DIFFERENT layers enforce requirements here, and they don't agree
+                    # with each other — checked both directly against
+                    # security-api-referral.xml, not assumed from one or the other:
+                    # (1) ReferralBeanImpl.updateReferralOut/.updateReferralIn (the business
+                    #     logic) reads facility_id/from_member/patient_id with a bare
+                    #     .asLong() and NO null check — omitting them throws an uncaught NPE
+                    #     (opaque 500). For "in", facility_id/party-field reads are dead code
+                    #     (commented out), so they have ZERO effect on the row even though...
+                    # (2) ...the REQUEST-LEVEL JSON schema (<jsontemplate name=
+                    #     "updateReferralJSON"/"updateReferralInJSON">) separately requires
+                    #     facility_id AND referral_date on BOTH directions
+                    #     (min-occurrences="1") — a field can be schema-required without the
+                    #     business logic ever using its value. Confirmed live: `respond`
+                    #     required facility_id the same way despite its own Java method never
+                    #     reading it (see that case for the same lesson).
+                    # Net: "in" update must still SEND a valid facility_id (schema), even
+                    # though changing it has no effect (business logic) — the merge above
+                    # supplies it from the existing record either way, so this is normally
+                    # transparent; only surfaces if the existing record is missing it.
+                    if direction == "out":
+                        if not facility_id or not from_member or not patient_id:
+                            return {
+                                "error": "facility_id, from_member, and patient_id are all required for direction='out' update (even if unchanged) and couldn't be filled in from the existing record",
+                                "guidance": "Provide facility_id, from_member, and patient_id explicitly — the backend rejects update calls missing any of these three with an opaque 500, not a validation error."
+                            }
+                    else:
+                        if not patient_id or not facility_id:
+                            return {
+                                "error": "patient_id and facility_id are both required for direction='in' update (even if unchanged) and couldn't be filled in from the existing record",
+                                "guidance": "Provide patient_id and facility_id explicitly. facility_id has no effect on an 'in' record but the API's request schema still requires it to be present."
+                            }
+                        # to_member/from_external_member/from_internal_member are dead code
+                        # in updateReferralIn (commented out server-side) — sending them is
+                        # harmless but silently has no effect. Those fields can't be changed
+                        # via update for direction="in" at all today.
+                    if not referral_date:
+                        return {
+                            "error": "referral_date is required for update (even if unchanged) and couldn't be filled in from the existing record",
+                            "guidance": "Provide referral_date explicitly (YYYY-MM-DD) — required by the API's request schema on both directions."
+                        }
+                    body = build_body()
+                    if not body:
+                        return {
+                            "error": "No fields provided to update",
+                            "guidance": "Provide at least one field to change."
+                        }
+                    response = await client.put(f"{base_path}/{referral_id}", data=body)
+                    if isinstance(response, dict) and response.get("error"):
+                        return {
+                            "error": response["error"],
+                            "guidance": "Could not update the referral. Verify referral_id and the fields provided."
+                        }
+                    # Same two issues as create: this response is double-nested, AND its
+                    # party-member fields are unreliable echoes (CONFIRMED LIVE — a PUT
+                    # that changed only priority, with from_member unchanged at ...117,
+                    # came back reporting from_member as ...110; an immediate GET
+                    # correctly showed ...117 still stored). Re-fetch for the authoritative
+                    # result instead of trusting this response's body at all.
+                    verify_response = await client.get(f"{base_path}/{referral_id}")
+                    if isinstance(verify_response, dict) and not verify_response.get("error"):
+                        result = _unwrap_get_response(verify_response, direction)
+                    else:
+                        result = _unwrap_mutation_response(response)
+                    result["guidance"] = "Referral updated."
+                    return strip_empty_values(_mask_notes_pointer(result))
+
+                case "respond":
+                    if not referral_id:
+                        return {
+                            "error": "referral_id required for respond",
+                            "guidance": "Provide the referral_id to respond to."
+                        }
+                    status_error = _validate_response_status(direction, "respond", response_status)
+                    if status_error:
+                        return status_error
+                    # CONFIRMED LIVE (2026-08-10): facility_id is required for respond on
+                    # BOTH directions. This is NOT visible in ReferralBeanImpl.addReferralResponse/
+                    # addReferralInResponse's Java body (which never reads facility_id at all,
+                    # which is what the earlier pass of this comment relied on) — it's enforced
+                    # by a SEPARATE request-level JSON-schema layer this tool missed originally:
+                    # security-api-referral.xml's <jsontemplate name="addReferralResponseJSON">
+                    # and <jsontemplate name="addReferralInResponseJSON">, both of which declare
+                    # `facility_id` with min-occurrences="1". A field can be schema-required
+                    # without the business logic ever using it — don't assume "the Java method
+                    # doesn't read X" means "X is optional."
+                    if not facility_id:
+                        return {
+                            "error": "facility_id required for respond",
+                            "guidance": "Provide facility_id — required by the API's request schema even though the response-recording logic itself doesn't use it."
+                        }
+
+                    # Everything else here IS genuinely optional per the same schema. "out"
+                    # doesn't accept diagnoses at all (no <key name="diagnoses"> in
+                    # addReferralResponseJSON) — only "in" does — so diagnoses is only sent
+                    # for direction="in".
+                    respond_body: Dict[str, Any] = {
+                        "facility_id": facility_id,
+                        "response_date": response_date.isoformat() if response_date else None,
+                        "response_notes": response_notes,
+                        "response_status": response_status,
+                        "chartnote_ids": chartnote_ids,
+                        "lab_ids": lab_ids,
+                        "document_ids": document_ids,
+                        "image_ids": image_ids,
+                        "growth_ids": growth_ids,
+                    }
+                    if direction == "in":
+                        respond_body["diagnoses"] = diagnoses_parsed
+                    respond_body = {k: v for k, v in respond_body.items() if v is not None}
+
+                    # facility_id alone (required above) isn't "a response" — require at
+                    # least one actual content field too.
+                    if not any(k != "facility_id" for k in respond_body):
+                        return {
+                            "error": "No response content provided",
+                            "guidance": "Provide at least one of response_date, response_notes, response_status"
+                                        + (", diagnoses" if direction == "in" else "") + "."
+                        }
+
+                    response = await client.post(f"{base_path}/{referral_id}/response", data=respond_body)
+                    if isinstance(response, dict) and response.get("error"):
+                        # CONFIRMED LIVE (2026-08-11): this endpoint currently returns a
+                        # generic "HTTP 500: Internal Error" for BOTH directions, on
+                        # multiple different, valid, pre-existing referral_ids with valid
+                        # facility_id/response_status — reproduced twice on direction="out"
+                        # alone. This is NOT an ID-mismatch or client-input problem (the
+                        # earlier theory below about "in" using the wrong linked id is a
+                        # real, separate risk from reading addReferralInResponse's
+                        # null-unguarded row dereference, but doesn't explain the "out"
+                        # failures) — it currently looks like a broader, backend-side issue
+                        # in this environment that no client-side fix here can work around.
+                        mismatch_hint = (
+                            " If this is a 500 on direction='in' specifically, double-check "
+                            "referral_id is really that referral's REF_IN_ID (from a "
+                            "direction='in' list/get call) and not its linked referral-out's "
+                            "id — they're different numbers even for a referral that started "
+                            "as an internal 'out' referral. If it fails on direction='out' too "
+                            "with the same generic error, this is likely a backend-side issue, "
+                            "not something fixable from this tool." if direction == "in" else
+                            " A generic 500 here (not a validation-style 400) on otherwise-valid "
+                            "input has been observed to be a backend-side issue, not fixable "
+                            "from this tool — confirm with whoever owns the API before assuming "
+                            "a client-side mistake."
+                        )
+                        return {
+                            "error": response["error"],
+                            "guidance": f"Could not record the response. Verify referral_id is correct.{mismatch_hint}"
+                        }
+                    # Same unreliable-echo risk as create/update — re-fetch rather than
+                    # trust this response's own body.
+                    verify_response = await client.get(f"{base_path}/{referral_id}")
+                    if isinstance(verify_response, dict) and not verify_response.get("error"):
+                        result = _unwrap_get_response(verify_response, direction)
+                    else:
+                        result = _unwrap_mutation_response(response)
+                    guidance = "Response recorded."
+                    if direction == "in":
+                        # Confirmed in ReferralBeanImpl.addReferralInResponse: if this "in"
+                        # record is linked to an internal outbound referral (REF_OUT_ID set),
+                        # responding here ALSO cascades response_date/response_notes onto
+                        # that linked "out" record and force-sets ITS response_status to the
+                        # literal string "To Be Reviewed" — regardless of the response_status
+                        # passed on this call. Real backend behavior, not a bug in this tool.
+                        guidance += (
+                            " Note: if this referral is linked to an internal outbound referral "
+                            "record, the backend also force-set that record's response_status "
+                            "to 'To Be Reviewed', regardless of the response_status passed here."
+                        )
+                    result["guidance"] = guidance
+                    return strip_empty_values(_mask_notes_pointer(result))
+
+        except Exception as e:
+            logger.error(f"Error in manageReferrals: {e}")
+            return {
+                "error": str(e),
+                "guidance": f"Failed to {action} referral (direction={direction}). Verify required fields are correct."
+            }

--- a/src/tools/referrals.py
+++ b/src/tools/referrals.py
@@ -446,6 +446,9 @@ async def manageReferrals(
                     return strip_empty_values(_mask_notes_pointer(created))
 
                 case "list":
+                    status_error = _validate_response_status(direction, "list", response_status)
+                    if status_error:
+                        return status_error
                     params: Dict[str, Any] = {}
                     if patient_id:
                         params["patient_id"] = patient_id
@@ -520,9 +523,14 @@ async def manageReferrals(
                             "error": "referral_id required for update",
                             "guidance": "Provide the referral_id to update."
                         }
-                    # Validate before the merge below — a value merged in from the
-                    # existing record is already valid by definition (it was accepted on
-                    # a prior write), only a caller-supplied value needs checking here.
+                    # Validate a caller-supplied value up front. A value merged in from
+                    # the existing record below is NOT necessarily valid for "update" —
+                    # it may have been set by a different action's schema (e.g. "respond"
+                    # accepts "To Be Reviewed" on direction="out", which "update" does not;
+                    # "create"/"respond" accept "Completed" on direction="in", which
+                    # "update" does not either) — see REFERRAL_STATUS_SETS. Re-checked
+                    # after the merge below, not assumed valid just because some prior
+                    # write accepted it.
                     status_error = _validate_response_status(direction, "update", response_status)
                     if status_error:
                         return status_error
@@ -567,6 +575,15 @@ async def manageReferrals(
                         referral_reason = existing.get("referral_reason")
                     if response_status is None:
                         response_status = existing.get("response_status")
+                        # The merged-in value may be valid for whatever action last set
+                        # it but not for "update"'s own narrower set (see the comment on
+                        # the pre-merge validation above). Drop it rather than send a
+                        # value guaranteed to be rejected — the caller never asked to
+                        # change this field, so silently omitting it (leaving it as
+                        # whatever the backend already has) is correct; sending it would
+                        # fail the whole update over a field the caller didn't touch.
+                        if response_status is not None and response_status not in REFERRAL_STATUS_SETS[direction]["update"]:
+                            response_status = None
                     if referral_date is None and existing.get("referral_date"):
                         try:
                             referral_date = date.fromisoformat(str(existing["referral_date"])[:10])

--- a/src/tools/referrals.py
+++ b/src/tools/referrals.py
@@ -240,29 +240,48 @@ async def manageReferrals(
     - "get": Fetch a single referral (referral_id required).
     - "update": Update an existing referral (referral_id required). The real backend
       does a FULL ROW OVERWRITE, not a partial patch — any field you omit gets wiped
-      to null/empty server-side. This tool fetches the existing referral first and
-      merges your fields on top of it, so omitting facility_id/patient_id/priority/
-      referral_reason/response_status/referral_date/the party fields will correctly
-      preserve their current values. facility_id, from_member (or to_member for
-      "in"), and patient_id are still hard-required by the backend either way —
-      the merge fills them from the existing record if you don't pass them.
-      NOT covered by this merge (still wiped if omitted, because "get" doesn't
-      return them or their round-trip shape isn't confirmed): referral_notes,
-      response_notes, related_encounter_id (encounter_id), diagnoses, insurance,
-      and the attachment-linking *_ids fields. Pass these explicitly every time
-      you want them to survive an update.
+      to null/empty server-side. This tool fetches the existing referral first (plus
+      a second read of the notes sub-resource for referral_notes) and merges your
+      fields on top of it, so omitting facility_id/patient_id/priority/
+      referral_reason/response_status/referral_date/the party fields/referral_notes/
+      diagnoses/insurance will correctly preserve their current values. facility_id,
+      from_member (or to_member for "in"), and patient_id are still hard-required by
+      the backend either way — the merge fills them from the existing record if you
+      don't pass them. response_notes survives untouched regardless of what you pass —
+      the backend has no write path for it on update at all.
+      NOT covered by this merge: related_encounter_id (encounter_id) — it isn't
+      readable back from "get" or any sub-resource, so it's genuinely wiped on any
+      update that doesn't pass encounter_id explicitly; the response guidance warns
+      when this happens rather than losing it silently. Separately, do NOT resend the
+      attachment-linking *_ids fields (chartnote_ids/lab_ids/document_ids/image_ids/
+      growth_ids) on update unless you actually mean to link something new —
+      addAttachmentsToRO inserts a fresh row per id and regenerates the chart-note PDF
+      on every call, so resending the same ids on each edit duplicates attachments and
+      files rather than being a harmless no-op.
       direction="in" additionally cannot change facility_id or its party fields
       via update at all — the backend ignores them for "in" regardless.
-    - "respond": Record a response to a referral (referral_id AND facility_id both
-      required — facility_id is enforced by the API's request schema even though
-      the response-recording logic itself never uses it, so don't assume it's
-      optional just because "get"/"update" treat it as re-derivable). Beyond that,
-      provide at least one of response_date, response_notes, response_status, or
-      (direction="in" only) diagnoses. chartnote_ids/lab_ids/document_ids/
-      image_ids/growth_ids link supporting records to the response, same
-      comma-separated-id convention as create/update. direction="out" does NOT
-      accept diagnoses — the API's schema has no such field for it; only
-      direction="in" writes a response diagnosis list.
+      SIDE EFFECT (direction="out" only): if this referral has an internal
+      to_internal_member, updateReferralOut unconditionally blanks the linked
+      "in" record's response_diagnoses (RESPONSE_DIAGNOSES set to "" server-side
+      regardless of what this call sends). Nothing in this tool's request body
+      can prevent it — flagging as a known backend-side quirk, not something
+      fixable client-side (candidate for a backend-side ticket).
+    - "respond": Record a response to a referral (referral_id, facility_id, AND
+      patient_id all required — facility_id is enforced by the API's request
+      schema even though the response-recording logic itself never uses it, so
+      don't assume it's optional just because "get"/"update" treat it as
+      re-derivable; patient_id is read unconditionally by the backend's
+      attachment-linking step and NPEs without it, on both directions, even on
+      a call with no attachments at all). Beyond that, provide at least one of
+      response_date, response_notes, response_status, or (direction="in" only)
+      diagnoses. Attachment-field support is NARROWER here than on
+      create/update: chartnote_ids/lab_ids/document_ids work on both
+      directions; image_ids works on direction="in" only; growth_ids doesn't
+      work on either direction — any of those two on direction="out"
+      (or growth_ids on direction="in") is dropped from the request with a
+      WARNING in the response guidance, not sent and silently ignored.
+      direction="out" does NOT accept diagnoses — the API's schema has no such
+      field for it; only direction="in" writes a response diagnosis list.
       QUIRK (direction="in" only): if this incoming referral is linked to an
       internal outbound referral record (i.e. it was auto-created when someone at
       this practice referred a patient to an internal provider), responding here
@@ -571,13 +590,18 @@ async def manageReferrals(
                     # so a call that only means to change e.g. priority doesn't silently
                     # blank everything else.
                     #
-                    # IMPORTANT — this merge is only as complete as what "get" returns.
-                    # ReferralOutResponseNew/ReferralInResponseNew (the "get" shape) does NOT
-                    # include referral_notes, response_notes, or related_encounter_id at all,
-                    # and diagnoses/insurance's stored round-trip shape (JSON string vs. parsed
-                    # array) isn't confirmed — so those fields are NOT safely preserved here.
-                    # If you're not explicitly setting one of those on this call, treat it as
-                    # being wiped, same as before this fix.
+                    # IMPORTANT — this merge is only as complete as what "get" (plus the
+                    # notes sub-resource, below) can recover. CONFIRMED LIVE (2026-08-25):
+                    # diagnoses/insurance ARE in the "get" shape, as JSON-encoded strings
+                    # (_parse_list_of_dicts already accepts that form) — merged below.
+                    # referral_notes is NOT in "get" at all, but IS recoverable from its own
+                    # GET .../notes sub-resource ({"referrals_out_notes": {"content": "..."}} /
+                    # referrals_in_notes for direction="in") — fetched and merged below.
+                    # response_notes has no equivalent sub-resource and updateReferralOut has
+                    # no row.set for it at all, so it survives untouched regardless — nothing
+                    # to merge. related_encounter_id is in neither "get" nor the notes
+                    # endpoint — genuinely unrecoverable; the caller is warned in guidance
+                    # when it's about to be cleared rather than losing it silently.
                     existing_raw = await client.get(f"{base_path}/{referral_id}")
                     if isinstance(existing_raw, dict) and existing_raw.get("error"):
                         return {
@@ -593,6 +617,40 @@ async def manageReferrals(
                     if not isinstance(existing, dict):
                         existing = {}
 
+                    # CONFIRMED LIVE (2026-08-25): diagnoses/insurance round-trip through
+                    # "get" as JSON-encoded strings — reuse the same parser create/respond
+                    # already use for caller input. A merged value that fails to parse is
+                    # dropped rather than crashing the whole update over it (unexpected but
+                    # not worth failing an otherwise-valid priority/status change).
+                    if diagnoses_parsed is None and existing.get("diagnoses") is not None:
+                        try:
+                            diagnoses_parsed = _parse_list_of_dicts(existing.get("diagnoses"), "diagnoses")
+                        except ValueError:
+                            pass
+                    if insurance_parsed is None and existing.get("insurance") is not None:
+                        try:
+                            insurance_parsed = _parse_list_of_dicts(existing.get("insurance"), "insurance")
+                        except ValueError:
+                            pass
+
+                    # CONFIRMED LIVE (2026-08-25): referral_notes isn't in "get" at all, but
+                    # has its own read endpoint — fetched only when the caller didn't already
+                    # supply a value, so an explicit referral_notes on this call always wins.
+                    # Best-effort: a failure here shouldn't block the rest of the update.
+                    if referral_notes is None:
+                        notes_response = await client.get(f"{base_path}/{referral_id}/notes")
+                        if isinstance(notes_response, dict) and not notes_response.get("error"):
+                            notes_key = "referrals_out_notes" if direction == "out" else "referrals_in_notes"
+                            notes_wrapper = notes_response.get(notes_key)
+                            if isinstance(notes_wrapper, dict) and notes_wrapper.get("content"):
+                                referral_notes = notes_wrapper["content"]
+
+                    # related_encounter_id is in neither "get" nor the notes endpoint —
+                    # genuinely unrecoverable. Warn rather than silently clear it.
+                    encounter_id_will_be_cleared = (
+                        encounter_id is None and bool(existing.get("related_encounter_id") or existing.get("encounter_id"))
+                    )
+
                     if facility_id is None:
                         facility_id = existing.get("facility_id")
                     if patient_id is None:
@@ -602,7 +660,14 @@ async def manageReferrals(
                     if referral_reason is None:
                         referral_reason = existing.get("referral_reason")
                     if response_status is None:
-                        merged_status = existing.get("response_status")
+                        # CONFIRMED LIVE (2026-08-27): a referral that has never had a
+                        # response recorded returns response_status="" (empty string),
+                        # not an absent key or null — a referral untouched by "respond"
+                        # would otherwise fail-closed below on every single update,
+                        # demanding an explicit response_status for a field that was
+                        # never actually set by anything. Treated the same as "no merged
+                        # value", not as an out-of-set value needing confirmation.
+                        merged_status = existing.get("response_status") or None
                         if merged_status is not None and merged_status not in REFERRAL_STATUS_SETS[direction]["update"]:
                             # The merged-in value is valid for whatever action last set
                             # it (e.g. "respond") but not for "update"'s own narrower
@@ -619,14 +684,36 @@ async def manageReferrals(
                             # the caller never touched, worse than the 400 this
                             # replaced. Fail instead and let the caller decide.
                             if direction == "out":
+                                # The ONLY value respond/create/update on direction="out" can
+                                # produce that isn't already in update's own set is
+                                # "To Be Reviewed" — respond/out's set is (Pending, "To Be
+                                # Reviewed", Reviewed), and create/update/out's set is
+                                # (Pending, Received, Reviewed); "To Be Reviewed" is the one
+                                # value exclusive to respond. It's also stamped by the
+                                # respond-cascade QUIRK documented on "respond": responding to
+                                # a linked internal "in" referral force-sets ITS linked "out"
+                                # record's status to this exact literal, regardless of what
+                                # was passed. No value in update's own set can reproduce it —
+                                # say so explicitly instead of asking for something impossible.
                                 return {
                                     "error": f"Stored response_status={merged_status!r} is not valid for direction='out' update",
                                     "guidance": (
-                                        f"This referral's response_status was set by a different action (e.g. 'respond') and "
-                                        f"can't be carried through 'update' as-is — the backend clears the column when "
-                                        f"response_status is left out of an update request, it does not leave it untouched. "
-                                        f"Provide an explicit response_status from {REFERRAL_STATUS_SETS[direction]['update']} "
-                                        f"to keep or change it as part of this call."
+                                        f"This referral's response_status ({merged_status!r}) can't be carried through "
+                                        f"'update' as-is — the backend clears the column when response_status is left out "
+                                        f"of an update request, it does not leave it untouched. "
+                                        + (
+                                            "'To Be Reviewed' specifically is not a value 'update' can ever set — it's "
+                                            "stamped by the backend itself when the linked inbound referral is responded "
+                                            "to (see the 'respond' cascade quirk), not by any direct write. No value in "
+                                            f"{REFERRAL_STATUS_SETS[direction]['update']} reproduces it, so this update "
+                                            "necessarily changes the status to one of those three — there's no way to "
+                                            "edit this referral while keeping 'To Be Reviewed'. If it needs to come back, "
+                                            "that only happens by responding again to the linked inbound referral "
+                                            "(action='respond', direction='in'), not by updating this record."
+                                            if merged_status == "To Be Reviewed" else
+                                            f"Provide an explicit response_status from {REFERRAL_STATUS_SETS[direction]['update']} "
+                                            f"to keep or change it as part of this call."
+                                        )
                                     )
                                 }
                             # direction="in": updateReferralIn has this same row.set
@@ -719,7 +806,16 @@ async def manageReferrals(
                         result = _unwrap_get_response(verify_response, direction)
                     else:
                         result = _unwrap_mutation_response(response)
-                    result["guidance"] = "Referral updated."
+                    guidance = "Referral updated."
+                    if encounter_id_will_be_cleared:
+                        guidance += (
+                            " WARNING: this referral had a linked encounter_id, and it's now "
+                            "been cleared — related_encounter_id can't be read back from "
+                            "'get' to merge automatically, so it's wiped on any update that "
+                            "doesn't pass encounter_id explicitly. Re-link it with an explicit "
+                            "encounter_id on a follow-up update if this wasn't intended."
+                        )
+                    result["guidance"] = guidance
                     return strip_empty_values(_mask_notes_pointer(result))
 
                 case "respond":
@@ -746,6 +842,17 @@ async def manageReferrals(
                             "error": "facility_id required for respond",
                             "guidance": "Provide facility_id — required by the API's request schema even though the response-recording logic itself doesn't use it."
                         }
+                    # LIVE TEST (2026-08-25): both directions' addAttachmentsToRO call
+                    # dereferences inputJson.get("patient_id").asLong() unconditionally
+                    # (no null guard) — an absent patient_id NPEs, caught generically and
+                    # surfaced as the opaque "HTTP 500: Internal Error" this endpoint has
+                    # returned on every prior attempt. patient_id was never sent here
+                    # before this fix. Required, not just included when present.
+                    if not patient_id:
+                        return {
+                            "error": "patient_id required for respond",
+                            "guidance": "Provide patient_id — the API's addAttachmentsToRO step dereferences it unconditionally and NPEs without it."
+                        }
 
                     # Everything else here IS genuinely optional per the same schema. "out"
                     # doesn't accept diagnoses at all (no <key name="diagnoses"> in
@@ -753,23 +860,34 @@ async def manageReferrals(
                     # for direction="in".
                     respond_body: Dict[str, Any] = {
                         "facility_id": facility_id,
+                        "patient_id": patient_id,
                         "response_date": response_date.isoformat() if response_date else None,
                         "response_notes": response_notes,
                         "response_status": response_status,
                         "chartnote_ids": chartnote_ids,
                         "lab_ids": lab_ids,
                         "document_ids": document_ids,
-                        "image_ids": image_ids,
-                        "growth_ids": growth_ids,
                     }
+                    # CONFIRMED LIVE (2026-08-25): unlike create/update, respond's real
+                    # attachment support is narrower than the shared *_ids field list
+                    # suggests. growth_ids is not a field on EITHER respond schema —
+                    # sending it fails the whole call with "HTTP 400: Extra key found in
+                    # JSON" (reproduced both directions). image_ids gets the same 400 on
+                    # direction="out", but IS accepted on direction="in" (a bad id there
+                    # 500s downstream instead — a schema hit, not a rejection). Dropped
+                    # rather than forwarded, same pattern as diagnoses below.
+                    growth_ids_dropped = bool(growth_ids)
+                    image_ids_dropped_for_out = direction == "out" and bool(image_ids)
+                    if direction == "in" and image_ids:
+                        respond_body["image_ids"] = image_ids
                     diagnoses_dropped_for_out = direction == "out" and diagnoses_parsed
                     if direction == "in":
                         respond_body["diagnoses"] = diagnoses_parsed
                     respond_body = {k: v for k, v in respond_body.items() if v is not None}
 
-                    # facility_id alone (required above) isn't "a response" — require at
-                    # least one actual content field too.
-                    if not any(k != "facility_id" for k in respond_body):
+                    # facility_id/patient_id alone (both required above) aren't "a
+                    # response" — require at least one actual content field too.
+                    if not any(k not in ("facility_id", "patient_id") for k in respond_body):
                         return {
                             "error": "No response content provided",
                             "guidance": "Provide at least one of response_date, response_notes, response_status"
@@ -778,28 +896,31 @@ async def manageReferrals(
 
                     response = await client.post(f"{base_path}/{referral_id}/response", data=respond_body)
                     if isinstance(response, dict) and response.get("error"):
-                        # CONFIRMED LIVE (2026-08-11): this endpoint currently returns a
-                        # generic "HTTP 500: Internal Error" for BOTH directions, on
-                        # multiple different, valid, pre-existing referral_ids with valid
-                        # facility_id/response_status — reproduced twice on direction="out"
-                        # alone. This is NOT an ID-mismatch or client-input problem (the
-                        # earlier theory below about "in" using the wrong linked id is a
-                        # real, separate risk from reading addReferralInResponse's
-                        # null-unguarded row dereference, but doesn't explain the "out"
-                        # failures) — it currently looks like a broader, backend-side issue
-                        # in this environment that no client-side fix here can work around.
+                        # HISTORY: this endpoint used to fail near-universally with a
+                        # generic "HTTP 500: Internal Error", previously assumed to be an
+                        # unfixable backend-side issue. Two real, confirmed-live causes are
+                        # now fixed above instead of worked around: (1) both directions'
+                        # addAttachmentsToRO dereferences patient_id unconditionally and
+                        # NPEs without it — patient_id is now required and sent; (2)
+                        # growth_ids (either direction) and image_ids (direction="out")
+                        # aren't real fields on this endpoint's schema and fail the whole
+                        # call with "HTTP 400: Extra key found in JSON" if sent — now
+                        # dropped instead of forwarded (see above). An error that still
+                        # reaches here is either a genuinely bad attachment id (confirmed
+                        # live: a nonexistent image_id 500s on direction="in" rather than
+                        # being cleanly rejected) or a real remaining backend issue — not
+                        # the previous default assumption.
                         mismatch_hint = (
-                            " If this is a 500 on direction='in' specifically, double-check "
-                            "referral_id is really that referral's REF_IN_ID (from a "
-                            "direction='in' list/get call) and not its linked referral-out's "
-                            "id — they're different numbers even for a referral that started "
-                            "as an internal 'out' referral. If it fails on direction='out' too "
-                            "with the same generic error, this is likely a backend-side issue, "
-                            "not something fixable from this tool." if direction == "in" else
-                            " A generic 500 here (not a validation-style 400) on otherwise-valid "
-                            "input has been observed to be a backend-side issue, not fixable "
-                            "from this tool — confirm with whoever owns the API before assuming "
-                            "a client-side mistake."
+                            " If this is direction='in', double-check referral_id is really "
+                            "that referral's REF_IN_ID (from a direction='in' list/get call) "
+                            "and not its linked referral-out's id — they're different numbers "
+                            "even for a referral that started as an internal 'out' referral. "
+                            "Also check any attachment ids (chartnote_ids/lab_ids/"
+                            "document_ids/image_ids) are real, existing records — a "
+                            "nonexistent one has been observed to 500 rather than fail "
+                            "cleanly." if direction == "in" else
+                            " Check any attachment ids (chartnote_ids/lab_ids/document_ids) "
+                            "are real, existing records for this patient/facility."
                         )
                         return {
                             "error": response["error"],
@@ -819,6 +940,18 @@ async def manageReferrals(
                             "responses don't support a diagnoses field (the API schema has no "
                             "such key for this direction; only direction='in' does). Nothing "
                             "downstream received these diagnoses from this call."
+                        )
+                    if growth_ids_dropped:
+                        guidance += (
+                            " WARNING: growth_ids was provided but NOT sent — respond has no "
+                            "growth_ids field on either direction; use 'update' if you need to "
+                            "link growth records."
+                        )
+                    if image_ids_dropped_for_out:
+                        guidance += (
+                            " WARNING: image_ids was provided but NOT sent — direction='out' "
+                            "respond has no image_ids field (direction='in' does); use 'update' "
+                            "if you need to link images to an outbound referral."
                         )
                     if direction == "in":
                         # Confirmed in ReferralBeanImpl.addReferralInResponse: if this "in"

--- a/src/tools/referrals.py
+++ b/src/tools/referrals.py
@@ -29,9 +29,15 @@ def _unwrap_get_response(response: Any, direction: str) -> Dict[str, Any]:
     backfill had to be supplied explicitly — exactly the "undocumented required
     fields" behavior reported live, repeatedly, and previously misdiagnosed as a
     stale MCP server rather than a real bug in this unwrapping.
+
+    Always returns a dict, matching the declared return type — a non-dict
+    response (e.g. a bare list, on a shape the real API hasn't been observed
+    to send but hasn't been ruled out either) is wrapped rather than passed
+    through, so every caller that does `result["guidance"] = ...` on this
+    function's return value can rely on that never raising.
     """
     if not isinstance(response, dict):
-        return response
+        return {"raw_response": response}
     key = "referral_out" if direction == "out" else "referral_in"
     inner = response.get(key)
     return inner if isinstance(inner, dict) else response
@@ -55,9 +61,13 @@ def _unwrap_mutation_response(response: Any) -> Dict[str, Any]:
     per _unwrap_get_response) and finding ...117 correctly stored. Callers of
     this unwrap function should still do a follow-up GET for anything beyond
     the bare ref_id — don't trust the unwrapped party-member fields either.
+
+    Always returns a dict, matching the declared return type — see
+    _unwrap_get_response's docstring for why that guarantee matters to
+    every caller that assigns `result["guidance"] = ...` on the return value.
     """
     if not isinstance(response, dict):
-        return response
+        return {"raw_response": response}
     outer = response.get("referrals")
     if isinstance(outer, dict):
         inner = outer.get("referrals")
@@ -106,6 +116,8 @@ def _parse_list_of_dicts(value: Optional[Union[str, List[Dict[str, Any]]]], fiel
             raise ValueError(f"{field_name} must be a JSON array of objects, or a valid JSON-encoded string of one")
     if not isinstance(value, list):
         raise ValueError(f"{field_name} must be a list of objects")
+    if not all(isinstance(item, dict) for item in value):
+        raise ValueError(f"{field_name} must be a list of objects — each item must be a JSON object, not a bare string or number")
     return value
 
 
@@ -429,16 +441,13 @@ async def manageReferrals(
                     # silently always None before this fix, hence "ref_id=None" in every
                     # prior create's guidance message. Unwrap to get the real ref_id.
                     created = _unwrap_mutation_response(response)
-                    # _unwrap_mutation_response falls back to returning `response`
-                    # unchanged when it isn't shaped as expected — which itself falls
-                    # back to whatever the API sent if that wasn't a dict either (e.g.
-                    # an array). Guard here so a create that actually succeeded doesn't
-                    # get reported as a failure just because we can't parse ref_id out
-                    # of it — that false failure is worse than a missing ref_id, since
-                    # the natural response to "Could not create" is a retry, which
-                    # would duplicate the referral that was, in fact, created.
-                    if not isinstance(created, dict):
-                        created = {"raw_response": created}
+                    # _unwrap_mutation_response guarantees a dict (wrapping a non-dict
+                    # response under "raw_response" itself) — a create that actually
+                    # succeeded but returned an unparseable shape (e.g. a bare array)
+                    # still reaches `created["guidance"] = ...` below safely instead of
+                    # raising and reporting a false "could not create", whose natural
+                    # follow-up (a retry) would duplicate the referral that was, in
+                    # fact, created.
                     ref_id = created.get("ref_id") or created.get("ref_in_id")
                     # Don't trust this response's own party-member fields (from_member/
                     # to_internal_member/etc.) — CONFIRMED LIVE they can echo back a
@@ -466,9 +475,9 @@ async def manageReferrals(
                         params["facility_id"] = facility_id
                     if response_status:
                         params["response_status"] = response_status
-                    if page:
+                    if page is not None:
                         params["page"] = page
-                    if per_page:
+                    if per_page is not None:
                         params["per_page"] = per_page
                     # Confirmed directly against the backend's criteria-resolver code
                     # (CharmTemplateHandler: REFERRAL_FROM_MEMBER_CR / REFERRAL_TO_MEMBER_CR
@@ -503,7 +512,12 @@ async def manageReferrals(
                     # "referralin" for direction="in" — NOT "referrals". Confirmed by reading
                     # the backend's own entity-format config, not guessed.
                     wrapper_key = "referralout" if direction == "out" else "referralin"
-                    referrals = response if isinstance(response, list) else response.get(wrapper_key, [])
+                    # `or []`, not `.get(key, [])` alone — the default only applies
+                    # when the key is absent, not when the API sends it explicitly
+                    # null for a zero-result response (seen elsewhere in this API's
+                    # responses), which would otherwise make the list comprehension
+                    # below raise on a plain empty-results call.
+                    referrals = response if isinstance(response, list) else (response.get(wrapper_key) or [])
                     referrals = [_mask_notes_pointer(r) for r in referrals]
                     result: Dict[str, Any] = {"referrals": referrals, "total_count": len(referrals)}
                     result["guidance"] = (

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -36,6 +36,7 @@ from api.api_client import CharmHealthAPIClient
 def _make_client(**overrides):
     kwargs = dict(
         base_url="https://example.test/api/ehr/v1",
+        api_key="k",
         refresh_token="rt",
         client_id="cid",
         client_secret="secret",

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -55,6 +55,21 @@ def _clear_shared_token_cache():
     CharmHealthAPIClient._shared_token_cache.clear()
 
 
+async def test_refresh_token_connection_error_does_not_mask_as_unbound_local():
+    """_refresh_token()'s `except Exception as e: logger.error(..., response.text)`
+    referenced `response` unconditionally — if client.post() itself raises
+    (connection refused, DNS failure, timeout: httpx.RequestError, not
+    HTTPStatusError) before `response` is ever assigned, that reference used
+    to raise its own UnboundLocalError, which propagates instead of the real
+    error, undermining "a failed refresh returns a clean error". The real
+    exception type must survive."""
+    client = _make_client()
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(side_effect=httpx.ConnectError("connection refused"))):
+        with pytest.raises(httpx.ConnectError):
+            await client._refresh_token()
+
+
 async def test_401_forces_exactly_one_refresh_and_retry_not_max_retries():
     client = _make_client(access_token="initial-token")
     await client.ensure_client()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,127 @@
+"""Tests for CharmHealthAPIClient._make_request's 401/refresh handling.
+
+Covers the fix for a real incident (2026-08-13): a single endpoint returning a
+401 (confirmed to be a scope gap, not an expired token — same pattern already
+documented for /drug/search) was retried up to max_retries (3) times, each
+retry forcibly clearing _shared_token_cache — a class-level cache keyed by
+client_id+refresh_token and therefore shared by every other in-flight call
+using the same credentials. When the underlying refresh_token turned out to
+be dead, one of those forced refreshes failed with `access_denied`, and
+because _get_auth_headers() was called *outside* _make_request's try block,
+that failure propagated as an unhandled exception — bypassing metrics and
+surfacing to the caller as a raw, ugly ValueError — while having already
+wiped the shared cache that unrelated tools (getPracticeInfo, managePatientLabs)
+were successfully reusing, taking them down too.
+
+Two fixes, tested here:
+1. A 401 now forces at most one refresh-and-retry per request (an
+   `auth_retried` flag), not up to max_retries — a 401 that survives a
+   freshly refreshed token is a scope problem a refresh can't fix, so further
+   retries only repeat the same failure and the same cache-wipe blast radius.
+2. _get_auth_headers() is now called inside the try block, so a failed
+   refresh returns a clean {"error": ...} dict instead of an unhandled
+   exception.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from api.api_client import CharmHealthAPIClient
+
+
+def _make_client(**overrides):
+    kwargs = dict(
+        base_url="https://example.test/api/ehr/v1",
+        refresh_token="rt",
+        client_id="cid",
+        client_secret="secret",
+        token_url="https://example.test/oauth/token",
+    )
+    kwargs.update(overrides)
+    return CharmHealthAPIClient(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _clear_shared_token_cache():
+    # The cache is class-level (shared across instances by design) — reset it
+    # around each test so tests don't leak state into each other.
+    CharmHealthAPIClient._shared_token_cache.clear()
+    yield
+    CharmHealthAPIClient._shared_token_cache.clear()
+
+
+async def test_401_forces_exactly_one_refresh_and_retry_not_max_retries():
+    client = _make_client(access_token="initial-token")
+    await client.ensure_client()
+
+    unauthorized = httpx.Response(
+        401, request=httpx.Request("GET", "https://example.test/x"), text="scope denied"
+    )
+    client._client.get = AsyncMock(return_value=unauthorized)
+
+    with patch.object(
+        client, "_refresh_token", new=AsyncMock(return_value="refreshed-token")
+    ) as mock_refresh:
+        result = await client.get("/referrals/out")
+
+    # A 401 that persists after a genuine refresh is a scope problem, not an
+    # expiry problem — the old code retried this 3 times (max_retries),
+    # wiping the shared cache on every attempt. Now it retries once.
+    assert result == {"error": "HTTP 401: scope denied"}
+    assert mock_refresh.await_count == 1
+    assert client._client.get.await_count == 2  # original attempt + the one retry
+
+
+async def test_401_retry_that_succeeds_returns_the_real_result():
+    client = _make_client(access_token="initial-token")
+    await client.ensure_client()
+
+    unauthorized = httpx.Response(401, request=httpx.Request("GET", "https://example.test/x"))
+    ok = httpx.Response(200, json={"code": "0", "referrals": []}, request=httpx.Request("GET", "https://example.test/x"))
+    client._client.get = AsyncMock(side_effect=[unauthorized, ok])
+
+    with patch.object(client, "_refresh_token", new=AsyncMock(return_value="refreshed-token")) as mock_refresh:
+        result = await client.get("/referrals/out")
+
+    assert result == {"code": "0", "referrals": []}
+    assert mock_refresh.await_count == 1
+
+
+async def test_failed_refresh_returns_clean_error_not_a_raised_exception():
+    client = _make_client()  # no access_token — first call must refresh before it can even try the request
+    await client.ensure_client()
+    client._client.get = AsyncMock()  # should never be reached
+
+    with patch.object(
+        client,
+        "_refresh_token",
+        new=AsyncMock(
+            side_effect=ValueError('Failed to obtain new token with response: {"error":"access_denied"}')
+        ),
+    ):
+        result = await client.get("/patients/123/allergies")
+
+    assert isinstance(result, dict)
+    assert "access_denied" in result["error"]
+    client._client.get.assert_not_awaited()
+
+
+async def test_401_does_not_clear_shared_cache_entry_belonging_to_a_different_refresh_token():
+    other_client = _make_client(refresh_token="someone-elses-refresh-token", access_token="their-token")
+    other_key = other_client._token_cache_key()
+    CharmHealthAPIClient._shared_token_cache[other_key] = {"token": "their-token", "expires_at": 9_999_999_999}
+
+    client = _make_client(access_token="initial-token")
+    await client.ensure_client()
+    unauthorized = httpx.Response(401, request=httpx.Request("GET", "https://example.test/x"), text="scope denied")
+    client._client.get = AsyncMock(return_value=unauthorized)
+
+    with patch.object(client, "_refresh_token", new=AsyncMock(return_value="refreshed-token")):
+        await client.get("/referrals/out")
+
+    # Only this client's own cache key should have been touched by its 401 handling.
+    assert other_key in CharmHealthAPIClient._shared_token_cache

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -110,6 +110,38 @@ async def test_failed_refresh_returns_clean_error_not_a_raised_exception():
     client._client.get.assert_not_awaited()
 
 
+async def test_refresh_endpoint_401_is_not_mistaken_for_the_target_apis_401():
+    """_refresh_token() posts to the OAuth TOKEN endpoint and calls
+    response.raise_for_status() there — if that endpoint itself returns a 401 (e.g. a
+    bad/rotated client_secret), it raises httpx.HTTPStatusError same as the target API
+    would. Fetching headers must be isolated from the target-request try/except: letting
+    this reach that except httpx.HTTPStatusError clause would treat e.response (the OAUTH
+    server's response) as if it were the target API's, wrongly firing a second refresh
+    (which cannot fix a bad client_secret) and mislabeling the OAuth server's error as the
+    target endpoint's."""
+    client = _make_client()  # no access_token — must refresh before attempting the request
+    await client.ensure_client()
+    client._client.get = AsyncMock()  # must never be reached
+
+    oauth_401 = httpx.HTTPStatusError(
+        "401 from token endpoint",
+        request=httpx.Request("POST", "https://example.test/oauth/token"),
+        response=httpx.Response(401, request=httpx.Request("POST", "https://example.test/oauth/token"), text="invalid_client"),
+    )
+    with patch.object(client, "_refresh_token", new=AsyncMock(side_effect=oauth_401)) as mock_refresh:
+        result = await client.get("/referrals/out")
+
+    # Exactly one refresh attempt — not two, which would mean the OAuth 401 got routed
+    # through the target-request retry-on-401 logic and triggered a second, pointless one.
+    assert mock_refresh.await_count == 1
+    client._client.get.assert_not_awaited()
+    assert isinstance(result, dict)
+    # Labeled as a refresh failure, not mislabeled as "HTTP 401: invalid_client" the way
+    # the target API's own 401 handler formats its errors — that format would wrongly
+    # imply /referrals/out itself returned this response.
+    assert "Token refresh failed" in result["error"]
+
+
 async def test_401_does_not_clear_shared_cache_entry_belonging_to_a_different_refresh_token():
     other_client = _make_client(refresh_token="someone-elses-refresh-token", access_token="their-token")
     other_key = other_client._token_cache_key()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -143,6 +143,29 @@ async def test_refresh_endpoint_401_is_not_mistaken_for_the_target_apis_401():
     assert "Token refresh failed" in result["error"]
 
 
+async def test_failed_token_fetch_still_ends_the_in_flight_gauge():
+    """start_api_call() marks the gauge active before the header fetch. The
+    early return on a failed refresh skips the `finally` below (which belongs
+    to the second try, entered only once headers succeed) — without an
+    explicit end_api_call() in this branch, that (endpoint, method, client_id)
+    combo would stick at "in flight" forever. A dead refresh token sends every
+    call down this path, so the dashboard would read as permanently stuck
+    mid-request during the exact incident this code exists to handle."""
+    client = _make_client()
+    await client.ensure_client()
+    client._client.get = AsyncMock()  # must never be reached
+
+    with patch.object(
+        client, "_refresh_token", new=AsyncMock(side_effect=ValueError("dead refresh_token"))
+    ), patch("api.api_client.end_api_call") as mock_end_api_call:
+        await client.get("/referrals/out")
+
+    mock_end_api_call.assert_called_once()
+    args, kwargs = mock_end_api_call.call_args
+    success = kwargs.get("success", args[4] if len(args) > 4 else None)
+    assert success is False
+
+
 async def test_401_does_not_clear_shared_cache_entry_belonging_to_a_different_refresh_token():
     other_client = _make_client(refresh_token="someone-elses-refresh-token", access_token="their-token")
     other_key = other_client._token_cache_key()

--- a/tests/test_clinical_data.py
+++ b/tests/test_clinical_data.py
@@ -114,6 +114,35 @@ async def test_add_medication_title_case_route_is_normalized_not_rejected(monkey
 
 
 @pytest.mark.asyncio
+async def test_add_medication_comments_is_dropped_with_warning(monkeypatch) -> None:
+    """CONFIRMED LIVE (2026-08-27) against the real sandbox: "comments"
+    fails the ENTIRE add/prescribe call with HTTP 400 "Extra key found in
+    JSON" (throwallerrors="true"), not a silent drop. "internal_comments" —
+    the field this repo's checked-out security-api-charts.xml shows for
+    this endpoint — was tried next and got the SAME rejection against this
+    live tenant, so that checkout doesn't match what's deployed here.
+    Dropped entirely rather than guessing further field names against a
+    real clinical write; the caller is warned instead."""
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/medications": {"medications": [{"id": "m1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="medication",
+        drug_name="Lisinopril 10mg", directions="Take 1 tablet by mouth once daily",
+        comments="Patient prefers generic.",
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert "comments" not in sent_data[0]
+    assert "internal_comments" not in sent_data[0]
+    assert "WARNING" in result["guidance"]
+    assert "comments" in result["guidance"]
+    assert "comments" not in sent_data[0]
+
+
+@pytest.mark.asyncio
 async def test_add_medication_invalid_route_returns_clean_error(monkeypatch) -> None:
     """A genuinely invalid value (not just a casing mismatch) must still be
     caught client-side with this tool's error/guidance convention, not sent
@@ -233,6 +262,7 @@ async def test_add_medication_without_allergies_has_no_warning(monkeypatch) -> N
     )
 
     assert "WARNING" not in result["guidance"]
+    assert result["guidance"].startswith("Medication")
 
 
 @pytest.mark.asyncio

--- a/tests/test_clinical_data.py
+++ b/tests/test_clinical_data.py
@@ -1,0 +1,146 @@
+"""Tests for managePatientDrugs' medication dispense-quantity handling and
+route/dose_form/dosage_unit validation.
+
+Covers two fixes:
+1. `quantity=0` being treated as "omitted" and silently defaulted to a
+   30-day supply, because the original code used a truthiness check
+   (`if quantity else 30.0`) rather than an explicit `is not None` check.
+2. route/dose_form/dosage_unit were briefly typed `Literal[DRUG_ROUTES]`
+   etc. — FastMCP validates the protocol-level schema before the function
+   body runs, so a caller sending title-case (e.g. route="Oral", which
+   models naturally emit) got a bare schema rejection and never saw this
+   tool's own {"error": ..., "guidance": ...} convention. Reverted to
+   Optional[str] with case-insensitive validation/normalization done in
+   the body instead, for substance_type="medication" only — the
+   supplement/vitamin path accepted any string before and still does.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from tools import clinical_data
+
+
+class _FakeAPIClient:
+    """Stands in for CharmHealthAPIClient — returns canned responses keyed
+    by exact endpoint string, per HTTP method, and records what was sent."""
+
+    def __init__(self, get_responses=None, post_responses=None):
+        self._get = get_responses or {}
+        self._post = post_responses or {}
+        self.post_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, endpoint, params=None):
+        return self._get.get(endpoint, {})
+
+    async def post(self, endpoint, data=None, params=None):
+        self.post_calls.append((endpoint, data))
+        return self._post[endpoint]
+
+
+def _patch_client(monkeypatch, fake_client) -> None:
+    monkeypatch.setattr(clinical_data, "CharmHealthAPIClient", lambda **kwargs: fake_client)
+
+
+@pytest.mark.asyncio
+async def test_add_medication_explicit_quantity_zero_is_sent_not_defaulted(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/medications": {"medications": [{"id": "m1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="medication",
+        drug_name="Lisinopril 10mg", directions="Take 1 tablet by mouth once daily",
+        quantity=0,
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert sent_data[0]["dispense"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_add_medication_omitted_quantity_defaults_to_30(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/medications": {"medications": [{"id": "m1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="medication",
+        drug_name="Lisinopril 10mg", directions="Take 1 tablet by mouth once daily",
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert sent_data[0]["dispense"] == 30.0
+
+
+@pytest.mark.asyncio
+async def test_add_medication_title_case_route_is_normalized_not_rejected(monkeypatch) -> None:
+    """A calling model naturally emits title case (route="Oral"); the real
+    catalog value is lowercase ("oral"). Must be accepted and normalized to
+    the canonical casing before being sent, not rejected."""
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/medications": {"medications": [{"id": "m1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="medication",
+        drug_name="Lisinopril 10mg", directions="Take 1 tablet by mouth once daily",
+        route="Oral", dose_form="Tablet", dosage_unit="MG",
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert sent_data[0]["route"] == "oral"
+    assert sent_data[0]["dose_form"] == "tablet"
+    assert sent_data[0]["dosage_unit"] == "mg"
+
+
+@pytest.mark.asyncio
+async def test_add_medication_invalid_route_returns_clean_error(monkeypatch) -> None:
+    """A genuinely invalid value (not just a casing mismatch) must still be
+    caught client-side with this tool's error/guidance convention, not sent
+    through to the real API."""
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/medications": {"medications": [{"id": "m1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_data.managePatientDrugs.fn(
+            action="add", patient_id="p1", substance_type="medication",
+            drug_name="Lisinopril 10mg", directions="Take 1 tablet by mouth once daily",
+            route="not-a-real-route",
+        )
+
+    assert "route" in str(exc_info.value)
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_add_supplement_route_accepts_any_string_unvalidated(monkeypatch) -> None:
+    """The supplement/vitamin path fed by these same three params accepted
+    any string before the Literal narrowing existed — that behavior must be
+    preserved, not retroactively validated against the drug catalog."""
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/supplements": {"supplements": [{"id": "s1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="supplement",
+        drug_name="Vitamin D3", dosage=5,
+        route="whatever the caller wants",
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert sent_data[0]["route"] == "whatever the caller wants"

--- a/tests/test_clinical_data.py
+++ b/tests/test_clinical_data.py
@@ -144,3 +144,40 @@ async def test_add_supplement_route_accepts_any_string_unvalidated(monkeypatch) 
 
     _, sent_data = fake.post_calls[0]
     assert sent_data[0]["route"] == "whatever the caller wants"
+
+
+@pytest.mark.asyncio
+async def test_add_supplement_explicit_quantity_zero_is_sent_not_dropped(monkeypatch) -> None:
+    """Same truthiness bug as the medication `dispense` fix, pre-existing on the
+    supplement path's `quantity` field (`if quantity:` treated an explicit 0 as
+    unset and silently dropped it from the request entirely — unlike
+    medication's `dispense`, there's no default to fall back to here, so the
+    field just vanished)."""
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/supplements": {"supplements": [{"id": "s1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="supplement",
+        drug_name="Vitamin D3", dosage=5, quantity=0,
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert sent_data[0]["quantity"] == 0
+
+
+@pytest.mark.asyncio
+async def test_add_supplement_omitted_quantity_is_not_sent(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/supplements": {"supplements": [{"id": "s1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1", substance_type="supplement",
+        drug_name="Vitamin D3", dosage=5,
+    )
+
+    _, sent_data = fake.post_calls[0]
+    assert "quantity" not in sent_data[0]

--- a/tests/test_clinical_data.py
+++ b/tests/test_clinical_data.py
@@ -17,6 +17,8 @@ Covers two fixes:
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from fastmcp.exceptions import ToolError
 
@@ -27,10 +29,12 @@ class _FakeAPIClient:
     """Stands in for CharmHealthAPIClient — returns canned responses keyed
     by exact endpoint string, per HTTP method, and records what was sent."""
 
-    def __init__(self, get_responses=None, post_responses=None):
+    def __init__(self, get_responses=None, post_responses=None, put_responses=None):
         self._get = get_responses or {}
         self._post = post_responses or {}
+        self._put = put_responses or {}
         self.post_calls = []
+        self.put_calls = []
 
     async def __aenter__(self):
         return self
@@ -44,6 +48,10 @@ class _FakeAPIClient:
     async def post(self, endpoint, data=None, params=None):
         self.post_calls.append((endpoint, data))
         return self._post[endpoint]
+
+    async def put(self, endpoint, data=None, params=None):
+        self.put_calls.append((endpoint, data))
+        return self._put[endpoint]
 
 
 def _patch_client(monkeypatch, fake_client) -> None:
@@ -181,3 +189,93 @@ async def test_add_supplement_omitted_quantity_is_not_sent(monkeypatch) -> None:
 
     _, sent_data = fake.post_calls[0]
     assert "quantity" not in sent_data[0]
+
+
+@pytest.mark.asyncio
+async def test_prescribe_surfaces_allergy_warning_without_logging_allergen_names(monkeypatch, caplog) -> None:
+    """The allergy safety check must reach the caller in the response guidance
+    — previously it was only logger.warning()'d and never attached to the
+    response, so the calling clinician/agent never actually saw which
+    allergies were found despite the tool's docstring claiming an automatic
+    check. Allergen names are PHI and must not appear in the application log
+    either — previously logged verbatim."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/patients/p1/allergies": {"allergies": [{"allergen": "Penicillin"}, {"allergen": "Peanuts"}]},
+        },
+        post_responses={"/patients/p1/medications": {"medications": [{"id": "m1"}]}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    with caplog.at_level(logging.WARNING):
+        result = await clinical_data.managePatientDrugs.fn(
+            action="prescribe", patient_id="p1", encounter_id="100010000000128111",
+            drug_name="Amoxicillin 500mg", directions="Take 1 capsule twice daily",
+        )
+
+    assert "Penicillin" in result["guidance"]
+    assert "Peanuts" in result["guidance"]
+    assert "Penicillin" not in caplog.text
+    assert "Peanuts" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_add_medication_without_allergies_has_no_warning(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={"/patients/p1/allergies": {"allergies": []}},
+        post_responses={"/patients/p1/medications": {"medications": [{"id": "m1"}]}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await clinical_data.managePatientDrugs.fn(
+        action="add", patient_id="p1",
+        drug_name="Lisinopril 10mg", directions="Take 1 tablet daily",
+    )
+
+    assert "WARNING" not in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_update_medication_preserves_explicit_dispense_zero(monkeypatch) -> None:
+    """Same truthiness bug as the `add`/`prescribe` quantity=0 fix, on the
+    read side: `update` fetches the current record to preserve fields the API
+    requires on every PUT, and `current_med.get("dispense") or 30` treated a
+    stored 0 (now a legitimately reachable value) as unset, silently
+    resetting it back to a 30-day supply on any unrelated update."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/patients/p1/medications": {"medications": [{
+                "patient_medication_id": "m1", "dispense": 0, "directions": "old directions",
+            }]},
+        },
+        put_responses={"/patients/p1/medications/m1": {"medications": [{"id": "m1"}]}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="update", patient_id="p1", record_id="m1",
+        directions="new directions",
+    )
+
+    _, sent_data = fake.put_calls[0]
+    assert sent_data["dispense"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_discontinue_medication_preserves_explicit_dispense_zero(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={
+            "/patients/p1/medications": {"medications": [{
+                "patient_medication_id": "m1", "dispense": 0, "directions": "old directions",
+            }]},
+        },
+        put_responses={"/patients/p1/medications/m1": {"medications": [{"id": "m1"}]}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await clinical_data.managePatientDrugs.fn(
+        action="discontinue", patient_id="p1", record_id="m1",
+    )
+
+    _, sent_data = fake.put_calls[0]
+    assert sent_data["dispense"] == 0.0

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -1,0 +1,185 @@
+"""Tests for managePatientLabs' order action.
+
+Fakes CharmHealthAPIClient so no real network/API access is needed — same
+pattern as test_referrals.py.
+
+order's order_tests items each need lab_id/lab_name/medical_record_id/
+lab_record_id — validated client-side before ever calling the API, since the
+real backend NPEs on a missing order_tests array entirely rather than
+returning a clean 400. There is no lookup action in this tool to discover
+those catalog values (search_labs/search_tests were removed — the real
+GET /labs/list and GET /lab/{id}/tests/search endpoints require an OAuth
+scope this app's credentials don't carry, confirmed via live testing against
+sandbox, not fixable from this tool). Callers must supply real catalog
+values from elsewhere.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from tools import clinical_support
+
+
+class _FakeAPIClient:
+    """Stands in for CharmHealthAPIClient — returns canned responses keyed
+    by exact endpoint string, per HTTP method."""
+
+    def __init__(self, get_responses=None, post_responses=None):
+        self._get = get_responses or {}
+        self._post = post_responses or {}
+        self.get_calls: list[tuple[str, dict]] = []
+        self.post_calls: list[tuple[str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, endpoint, params=None):
+        self.get_calls.append((endpoint, params or {}))
+        return self._get[endpoint]
+
+    async def post(self, endpoint, data=None, params=None):
+        self.post_calls.append((endpoint, data or {}))
+        return self._post[endpoint]
+
+
+def _patch_client(monkeypatch, fake_client) -> None:
+    monkeypatch.setattr(clinical_support, "CharmHealthAPIClient", lambda **kwargs: fake_client)
+
+
+# ── order ────────────────────────────────────────────────────────────────
+
+
+_VALID_TEST = {"lab_id": "1", "lab_name": "LabCorp", "medical_record_id": "500", "lab_record_id": "600"}
+
+
+@pytest.mark.asyncio
+async def test_order_missing_patient_id_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_support.managePatientLabs.fn(action="order", encounter_id="e1", order_tests=[_VALID_TEST])
+
+    assert json.loads(str(exc_info.value))["error"] == "patient_id required for order"
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_order_requires_encounter_or_member_and_facility(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_support.managePatientLabs.fn(
+            action="order", patient_id="p1", order_tests=[_VALID_TEST],
+        )
+
+    assert "encounter_id" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_order_requires_non_empty_order_tests(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_support.managePatientLabs.fn(
+            action="order", patient_id="p1", encounter_id="e1",
+        )
+
+    assert "order_tests" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_order_rejects_test_missing_required_fields(monkeypatch) -> None:
+    """The real backend NPEs on a malformed order_tests item rather than
+    400ing cleanly — catch this client-side instead."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_support.managePatientLabs.fn(
+            action="order", patient_id="p1", encounter_id="e1",
+            order_tests=[{"lab_id": "1", "lab_name": "LabCorp"}],  # missing medical_record_id/lab_record_id
+        )
+
+    error = json.loads(str(exc_info.value))["error"]
+    assert "order_tests[0]" in error
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_order_happy_path_with_encounter_id(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/labs/order": {"lab_orders_list": ["9001", "9002"]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await clinical_support.managePatientLabs.fn(
+        action="order", patient_id="p1", encounter_id="e1", order_tests=[_VALID_TEST],
+    )
+
+    endpoint, sent_body = fake.post_calls[0]
+    assert endpoint == "/patients/p1/labs/order"
+    assert sent_body == {"encounter_id": "e1", "order_tests": [_VALID_TEST]}
+    assert result["lab_order_ids"] == ["9001", "9002"]
+    assert result["guidance"] == "Lab order placed."
+
+
+@pytest.mark.asyncio
+async def test_order_happy_path_with_member_and_facility(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={
+        "/patients/p1/labs/order": ["9001"],
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await clinical_support.managePatientLabs.fn(
+        action="order", patient_id="p1", member_id="m1", facility_id="f1",
+        ordered_date=datetime.date(2026, 8, 7), order_tests=[_VALID_TEST],
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert sent_body["member_id"] == "m1"
+    assert sent_body["facility_id"] == "f1"
+    assert sent_body["ordered_date"] == "2026-08-07"
+    # Bare-array response (not wrapped) must also parse correctly.
+    assert result["lab_order_ids"] == ["9001"]
+
+
+@pytest.mark.asyncio
+async def test_order_accepts_stringified_order_tests(monkeypatch) -> None:
+    fake = _FakeAPIClient(post_responses={"/patients/p1/labs/order": {"lab_orders_list": ["9001"]}})
+    _patch_client(monkeypatch, fake)
+
+    await clinical_support.managePatientLabs.fn(
+        action="order", patient_id="p1", encounter_id="e1",
+        order_tests=json.dumps([_VALID_TEST]),
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert sent_body["order_tests"] == [_VALID_TEST]
+
+
+@pytest.mark.asyncio
+async def test_order_rejects_malformed_order_tests_json_string(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_support.managePatientLabs.fn(
+            action="order", patient_id="p1", encounter_id="e1",
+            order_tests="not valid json{",
+        )
+
+    assert "order_tests" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -183,3 +183,23 @@ async def test_order_rejects_malformed_order_tests_json_string(monkeypatch) -> N
 
     assert "order_tests" in json.loads(str(exc_info.value))["error"]
     assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_order_rejects_order_tests_with_non_dict_elements(monkeypatch) -> None:
+    """`'["12345"]'` parses as valid JSON and IS a list, so the earlier
+    list-only check passed it through — then `t.get(k)` on a bare string
+    element raised AttributeError, surfacing as an opaque
+    "'str' object has no attribute 'get'" instead of the guidance written
+    for a malformed order_tests item."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await clinical_support.managePatientLabs.fn(
+            action="order", patient_id="p1", encounter_id="e1",
+            order_tests='["12345"]',
+        )
+
+    assert "order_tests" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -72,7 +72,11 @@ class _FakeAPIClient:
 
     async def get(self, endpoint, params=None):
         self.get_calls.append((endpoint, params or {}))
-        responses = self._get[endpoint]
+        # Defaults to {} for an unconfigured endpoint (e.g. update's notes
+        # sub-resource fetch, made on every update unless referral_notes was
+        # already supplied) rather than KeyError — tests that don't care
+        # about that call don't need to configure a response for it.
+        responses = self._get.get(endpoint, {})
         if isinstance(responses, list):
             idx = min(self._get_counts.get(endpoint, 0), len(responses) - 1)
             self._get_counts[endpoint] = idx + 1
@@ -648,6 +652,155 @@ async def test_update_out_merges_omitted_fields_from_existing_record(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_update_merges_diagnoses_and_insurance_from_existing_record(monkeypatch) -> None:
+    """CONFIRMED LIVE (2026-08-25): diagnoses/insurance round-trip through
+    "get" as JSON-encoded strings, unlike referral_notes/response_notes/
+    related_encounter_id. Recoverable, so merged like the other fields."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+                "diagnoses": '[{"name": "Hypertension", "code": "I10"}]',
+                "insurance": '[{"name": "Aetna", "id": "ins1"}]',
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["diagnoses"] == [{"name": "Hypertension", "code": "I10"}]
+    assert sent_body["insurance"] == [{"name": "Aetna", "id": "ins1"}]
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_diagnoses_wins_over_merged(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+                "diagnoses": '[{"name": "Hypertension", "code": "I10"}]',
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+        diagnoses=[{"name": "Diabetes", "code": "E11"}],
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["diagnoses"] == [{"name": "Diabetes", "code": "E11"}]
+
+
+@pytest.mark.asyncio
+async def test_update_fetches_referral_notes_from_notes_endpoint(monkeypatch) -> None:
+    """CONFIRMED LIVE (2026-08-25): GET /referrals/out/{id}/notes returns
+    {"referrals_out_notes": {"content": "..."}} — the real note text,
+    unlike get's own raw file-pointer. Fetched and merged only when the
+    caller didn't already supply referral_notes on this call."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+            }),
+            "/referrals/out/999/notes": {
+                "code": "0", "message": "success",
+                "referrals_out_notes": {"content": "Existing note text.\n"},
+            },
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["referral_notes"] == "Existing note text.\n"
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_referral_notes_skips_notes_fetch(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+        referral_notes="New note text.",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["referral_notes"] == "New note text."
+    assert ("/referrals/out/999/notes", {}) not in fake.get_calls
+
+
+@pytest.mark.asyncio
+async def test_update_warns_when_encounter_id_will_be_cleared(monkeypatch) -> None:
+    """related_encounter_id has no recovery path (not in "get", no
+    sub-resource) — genuinely wiped if omitted. Must warn instead of
+    silently losing it."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+                "related_encounter_id": "enc1",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    assert "WARNING" in result["guidance"]
+    assert "encounter_id" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_update_no_encounter_warning_when_explicit_or_absent(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+                "related_encounter_id": "enc1",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+        encounter_id="enc1",
+    )
+
+    assert "WARNING" not in result["guidance"]
+
+
+@pytest.mark.asyncio
 async def test_update_survives_non_dict_verify_and_mutation_response(monkeypatch) -> None:
     """Same non-dict-response risk as create — if both the verify-GET and the
     PUT's own response come back non-dict-shaped, `result["guidance"] = ...`
@@ -709,6 +862,66 @@ async def test_update_out_fails_when_merged_response_status_invalid_for_update(m
 
     assert "To Be Reviewed" in json.loads(str(exc_info.value))["error"]
     assert fake.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_out_to_be_reviewed_guidance_names_cascade_and_restore_path(monkeypatch) -> None:
+    """The old guidance asked the caller to 'provide an explicit
+    response_status from (Pending, Received, Reviewed) to keep it' — but
+    none of those three IS 'To Be Reviewed', so the instruction couldn't be
+    followed. Must say so directly: no update value preserves it, name the
+    respond cascade as the cause, and give the restore path (respond again
+    on the linked inbound referral)."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "to_internal_member_id": "2",
+                "referral_date": "2026-08-06", "priority": "Normal",
+                "response_status": "To Be Reviewed",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="update", direction="out", referral_id="999", priority="Urgent",
+        )
+
+    guidance = json.loads(str(exc_info.value))["guidance"]
+    assert "cascade" in guidance
+    assert "respond" in guidance
+    assert "direction='in'" in guidance
+
+
+@pytest.mark.asyncio
+async def test_update_out_empty_string_status_does_not_trigger_fail_closed(monkeypatch) -> None:
+    """CONFIRMED LIVE (2026-08-27): a referral that's never had a response
+    recorded returns response_status="" (empty string), not an absent key.
+    Without this fix, EVERY plain out-direction update on such a referral
+    would hit the fail-closed error meant for a genuinely out-of-set merged
+    value — demanding an explicit response_status for a field nothing had
+    ever actually set."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-06",
+                "response_status": "",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert "response_status" not in sent_body
 
 
 @pytest.mark.asyncio
@@ -987,6 +1200,7 @@ async def test_respond_out_trusts_verify_get_and_sends_correct_body(monkeypatch)
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1",
         response_date=datetime.date(2026, 8, 7),
         response_notes="Patient seen, no further action needed.",
         response_status="Reviewed",
@@ -996,12 +1210,33 @@ async def test_respond_out_trusts_verify_get_and_sends_correct_body(monkeypatch)
     assert endpoint == "/referrals/out/999/response"
     assert sent_body == {
         "facility_id": "f1",
+        "patient_id": "p1",
         "response_date": "2026-08-07",
         "response_notes": "Patient seen, no further action needed.",
         "response_status": "Reviewed",
     }
     assert result["response_status"] == "Reviewed"
     assert result["guidance"] == "Response recorded."
+
+
+@pytest.mark.asyncio
+async def test_respond_missing_patient_id_returns_clean_error(monkeypatch) -> None:
+    """CONFIRMED LIVE (2026-08-25): both directions' addAttachmentsToRO
+    dereferences patient_id unconditionally and NPEs without it — this is
+    the real cause behind every generic "HTTP 500: Internal Error" respond
+    had returned before this fix. Required client-side now, not just
+    included when present."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="respond", direction="out", referral_id="999", facility_id="f1",
+            response_status="Reviewed",
+        )
+
+    assert json.loads(str(exc_info.value))["error"] == "patient_id required for respond"
+    assert fake.post_calls == []
 
 
 @pytest.mark.asyncio
@@ -1017,6 +1252,7 @@ async def test_respond_survives_non_dict_verify_and_mutation_response(monkeypatc
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1",
         response_status="Reviewed",
     )
 
@@ -1056,6 +1292,7 @@ async def test_respond_out_does_not_send_diagnoses(monkeypatch) -> None:
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1",
         response_status="Reviewed",
         diagnoses=[{"name": "Hypertension", "code": "I10"}],
     )
@@ -1078,10 +1315,60 @@ async def test_respond_out_without_diagnoses_has_no_warning(monkeypatch) -> None
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1",
         response_status="Reviewed",
     )
 
     assert "WARNING" not in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_respond_out_drops_growth_ids_and_image_ids(monkeypatch) -> None:
+    """CONFIRMED LIVE (2026-08-25): growth_ids isn't a real field on respond
+    for either direction, and image_ids isn't real on direction="out" —
+    sending either fails the whole call with "HTTP 400: Extra key found in
+    JSON". Both dropped from the outgoing body on direction="out", with a
+    WARNING each in guidance rather than a hard failure or silent no-op."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out/999/response": _mutation({"ref_id": "999"})},
+        get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1", response_status="Reviewed",
+        growth_ids="1,2", image_ids="3,4",
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert "growth_ids" not in sent_body
+    assert "image_ids" not in sent_body
+    assert "growth_ids" in result["guidance"]
+    assert "image_ids" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_respond_in_sends_image_ids_but_not_growth_ids(monkeypatch) -> None:
+    """image_ids IS a real field on direction="in" respond (confirmed live —
+    only direction="out" rejects it); growth_ids is dropped on both."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/in/500/response": _mutation({"ref_in_id": "500"})},
+        get_responses={"/referrals/in/500": _get_in({"ref_in_id": "500"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="in", referral_id="500", facility_id="f1",
+        patient_id="p1", response_status="Completed",
+        growth_ids="1,2", image_ids="3,4",
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert sent_body["image_ids"] == "3,4"
+    assert "growth_ids" not in sent_body
+    assert "growth_ids" in result["guidance"]
+    assert "image_ids" not in result["guidance"]
 
 
 @pytest.mark.asyncio
@@ -1094,6 +1381,7 @@ async def test_respond_in_sends_diagnoses_and_notes_cascade_quirk(monkeypatch) -
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="in", referral_id="500", facility_id="f1",
+        patient_id="p1",
         response_status="Completed",
         diagnoses=[{"name": "Hypertension", "code": "I10"}],
     )
@@ -1128,6 +1416,7 @@ async def test_respond_no_content_returns_clean_error(monkeypatch) -> None:
     with pytest.raises(ToolError) as exc_info:
         await referrals.manageReferrals.fn(
             action="respond", direction="out", referral_id="999", facility_id="f1",
+            patient_id="p1",
         )
 
     assert json.loads(str(exc_info.value))["error"] == "No response content provided"
@@ -1152,6 +1441,7 @@ async def test_respond_response_masks_raw_notes_pointer_on_verify_fallback(monke
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1",
         response_notes="Patient seen, cleared for surgery.",
     )
 
@@ -1195,6 +1485,7 @@ async def test_respond_out_accepts_to_be_reviewed(monkeypatch) -> None:
 
     result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
+        patient_id="p1",
         response_status="To Be Reviewed",
     )
 

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -1,0 +1,922 @@
+"""Tests for manageReferrals (create/list/get/update/respond, direction="out"|"in").
+
+Fakes CharmHealthAPIClient so no real network/API access is needed — same
+pattern as test_billing.py. Particular focus on things confirmed live against
+a real sandbox (see docs/ch-733-progress.md), most recently (2026-08-11):
+
+1. list's response-wrapper key is "referralout"/"referralin", not "referrals".
+2. get's response is nested one level under "referral_out"/"referral_in"
+   (plus "code"/"message" at the top), not flat — this silently broke
+   update's fetch-then-merge (every `existing.get(...)` returned None) and
+   was misdiagnosed as a stale MCP server for a while before being traced to
+   this actual unwrapping bug.
+3. create/update/respond's response is nested TWO levels under
+   "referrals"/"referrals" — and, separately, its own party-member fields
+   (from_member/to_internal_member/etc.) are NOT reliable confirmation of
+   what got persisted (confirmed live: sent ...117, that response said
+   ...110, an immediate GET correctly showed ...117 stored). This tool now
+   re-fetches via "get" after a successful create/update/respond and returns
+   THAT as the authoritative result, falling back to the raw (unwrapped)
+   mutation response only if the verify-fetch itself fails.
+4. referral_notes/response_notes are raw internal file pointers, not the
+   text sent — masked rather than surfaced as content. Note: the verify-GET
+   success path never surfaces either field at all (the real "get" entity
+   doesn't return them), so masking is now primarily exercised via the
+   fallback path (verify-GET fails, falls back to the raw mutation response,
+   which DOES include them).
+5. response_status's valid set genuinely differs per (direction, action) —
+   validated client-side against a confirmed map, not a single shared enum.
+
+"delete" was deliberately removed (deleteReferralOut throws an uncaught NPE
+server-side for any referral with no internal-member party — no client-side
+workaround), so there's nothing to test for it.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from tools import referrals
+
+
+class _FakeAPIClient:
+    """Stands in for CharmHealthAPIClient — returns canned responses keyed
+    by exact endpoint string, per HTTP method.
+
+    A get_responses/post_responses/put_responses value may be a single dict
+    (always returned for that endpoint) or a list of dicts (consumed in
+    order across successive calls to that same endpoint, last one repeating
+    once exhausted) — the list form is what lets a test simulate "the first
+    GET to this endpoint succeeds, a later GET to the SAME endpoint fails",
+    needed for update's pre-fetch-then-verify-fetch pattern.
+    """
+
+    def __init__(self, get_responses=None, post_responses=None, put_responses=None):
+        self._get = get_responses or {}
+        self._post = post_responses or {}
+        self._put = put_responses or {}
+        self._get_counts: dict[str, int] = {}
+        self.get_calls: list[tuple[str, dict]] = []
+        self.post_calls: list[tuple[str, dict]] = []
+        self.put_calls: list[tuple[str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, endpoint, params=None):
+        self.get_calls.append((endpoint, params or {}))
+        responses = self._get[endpoint]
+        if isinstance(responses, list):
+            idx = min(self._get_counts.get(endpoint, 0), len(responses) - 1)
+            self._get_counts[endpoint] = idx + 1
+            return responses[idx]
+        return responses
+
+    async def post(self, endpoint, data=None, params=None):
+        self.post_calls.append((endpoint, data or params or {}))
+        return self._post[endpoint]
+
+    async def put(self, endpoint, data=None, params=None):
+        self.put_calls.append((endpoint, data or {}))
+        return self._put[endpoint]
+
+
+def _patch_client(monkeypatch, fake_client) -> None:
+    monkeypatch.setattr(referrals, "CharmHealthAPIClient", lambda **kwargs: fake_client)
+
+
+def _get_out(fields: dict) -> dict:
+    """The real shape of GET /referrals/out/{id} — fields nested under "referral_out"."""
+    return {"code": "0", "message": "success", "referral_out": fields}
+
+
+def _get_in(fields: dict) -> dict:
+    """The real shape of GET /referrals/in/{id} — fields nested under "referral_in"."""
+    return {"code": "0", "message": "success", "referral_in": fields}
+
+
+def _mutation(fields: dict, message: str = "success") -> dict:
+    """The real shape of create/update/respond's own response — fields
+    double-nested under "referrals"/"referrals"."""
+    return {"code": "0", "message": message, "referrals": {"referrals": fields}}
+
+
+# ── _unwrap_get_response / _unwrap_mutation_response ────────────────────
+
+
+def test_unwrap_get_response_extracts_nested_fields() -> None:
+    wrapped = _get_out({"ref_id": "999", "patient_id": "p1"})
+    assert referrals._unwrap_get_response(wrapped, "out") == {"ref_id": "999", "patient_id": "p1"}
+
+
+def test_unwrap_get_response_falls_back_on_unexpected_shape() -> None:
+    """If the wrapper key isn't present (e.g. an error dict slipped through),
+    return the input unchanged rather than crashing or losing the error."""
+    flat = {"error": "something else"}
+    assert referrals._unwrap_get_response(flat, "out") == flat
+
+
+def test_unwrap_mutation_response_extracts_double_nested_fields() -> None:
+    wrapped = _mutation({"ref_id": "999", "priority": "Urgent"})
+    assert referrals._unwrap_mutation_response(wrapped) == {"ref_id": "999", "priority": "Urgent"}
+
+
+def test_unwrap_mutation_response_falls_back_on_unexpected_shape() -> None:
+    flat = {"ref_id": "999"}
+    assert referrals._unwrap_mutation_response(flat) == flat
+
+
+# ── create ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_out_trusts_verify_get_over_mutation_echo(monkeypatch) -> None:
+    """The create response's own party-member fields are NOT reliable —
+    confirmed live (sent ...117, response echoed ...110, a follow-up GET
+    correctly showed ...117 persisted). The tool must return the verify-GET's
+    data, not the raw create response's."""
+    fake = _FakeAPIClient(
+        post_responses={
+            "/referrals/out": _mutation({"ref_id": "999", "from_member": "110"}),  # unreliable echo
+        },
+        get_responses={
+            "/referrals/out/999": _get_out({"ref_id": "999", "from_member_id": "117"}),  # authoritative
+        },
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="create", direction="out",
+        facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+        from_member="117", to_internal_member="2", patient_id="p1",
+    )
+
+    assert result["ref_id"] == "999"
+    assert result["from_member_id"] == "117"
+    assert "ref_id=999" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_create_falls_back_to_mutation_response_if_verify_get_fails(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out": _mutation({"ref_id": "999", "priority": "Normal"})},
+        get_responses={"/referrals/out/999": {"error": "simulated verify failure"}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="create", direction="out",
+        facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+        from_member="1", to_internal_member="2",
+    )
+
+    assert result["ref_id"] == "999"
+    assert result["priority"] == "Normal"
+
+
+@pytest.mark.asyncio
+async def test_create_out_missing_facility_or_date_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="out", from_member="1", to_internal_member="2",
+        )
+
+    assert "facility_id and referral_date" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_out_missing_from_member_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="out",
+            facility_id="f1", referral_date=datetime.date(2026, 8, 6), to_internal_member="2",
+        )
+
+    assert "from_member" in json.loads(str(exc_info.value))["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_out_requires_a_receiving_party(monkeypatch) -> None:
+    """Neither to_external_member nor to_internal_member provided — must fail
+    before ever calling the API, not send a half-formed referral."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="out",
+            facility_id="f1", referral_date=datetime.date(2026, 8, 6), from_member="1",
+        )
+
+    assert "to_external_member or to_internal_member" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_in_requires_to_member_and_a_sending_party(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="in",
+            facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+        )
+
+    assert "to_member" in json.loads(str(exc_info.value))["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_response_masks_raw_notes_pointer_on_verify_fallback(monkeypatch) -> None:
+    """REFERRAL_NOTES is a raw DFS file-pointer server-side — confirmed live
+    with a garbled value. The real "get" entity never returns referral_notes
+    at all, so this is only reachable via the verify-GET-fails fallback path
+    (which returns the raw mutation response) — must still mask it there."""
+    fake = _FakeAPIClient(
+        post_responses={
+            "/referrals/out": _mutation({
+                "ref_id": "999",
+                "referral_notes": "1786019884879_referral.html!@>NN1:-4152206861348658358",
+            }),
+        },
+        get_responses={"/referrals/out/999": {"error": "simulated verify failure"}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="create", direction="out",
+        facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+        from_member="1", to_internal_member="2",
+        referral_notes="Please see patient for follow-up.",
+    )
+
+    assert result.get("referral_notes") is None
+    assert "internal file pointer" in result["_notes_fields_note"]
+
+
+@pytest.mark.asyncio
+async def test_create_diagnoses_accepts_stringified_json(monkeypatch) -> None:
+    """LLMs sometimes stringify array-typed params — diagnoses/insurance must
+    accept a JSON-encoded string, not just a native list."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out": _mutation({"ref_id": "999"})},
+        get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="create", direction="out",
+        facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+        from_member="1", to_internal_member="2",
+        diagnoses=json.dumps([{"name": "Hypertension", "code": "I10"}]),
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert sent_body["diagnoses"] == [{"name": "Hypertension", "code": "I10"}]
+
+
+@pytest.mark.asyncio
+async def test_create_diagnoses_rejects_malformed_json_string(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="out",
+            facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+            from_member="1", to_internal_member="2",
+            diagnoses="not valid json{",
+        )
+
+    assert "diagnoses" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_out_rejects_to_be_reviewed(monkeypatch) -> None:
+    """"To Be Reviewed" is respond/out's set, not create's — create/update/out
+    use Pending|Received|Reviewed."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="out",
+            facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+            from_member="1", to_internal_member="2",
+            response_status="To Be Reviewed",
+        )
+
+    assert "Received" in json.loads(str(exc_info.value))["guidance"]
+    assert fake.post_calls == []
+
+
+# ── list ───────────────────────────────────────────────────────────────
+# Confirmed live: the real response wraps the array under a key matching the
+# outer XML tag name in EntityXMLFormat.xml ("referralout"/"referralin"),
+# not "referrals" — this was a real bug (always returned empty) until fixed.
+
+
+@pytest.mark.asyncio
+async def test_list_out_reads_the_real_wrapper_key(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/out": {"referralout": [{"ref_id": "1"}, {"ref_id": "2"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="list", direction="out")
+
+    assert result["total_count"] == 2
+    assert "2 referral(s)" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_list_in_reads_the_real_wrapper_key(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/in": {"referralin": [{"ref_id": "1"}]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="list", direction="in")
+
+    assert result["total_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_no_results_reports_correctly(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={"/referrals/out": {"referralout": []}})
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="list", direction="out")
+
+    assert result["total_count"] == 0
+    assert "No referrals found" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_list_out_filter_params_use_confirmed_names(monkeypatch) -> None:
+    """Confirmed directly against CharmTemplateHandler's criteria-resolver
+    code — from_member_id/to_internal_member_id/to_external_member_id, not
+    the create-body field names (from_member/to_internal_member/...)."""
+    fake = _FakeAPIClient(get_responses={"/referrals/out": {"referralout": []}})
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="list", direction="out",
+        from_member="1", to_internal_member="2", to_external_member="3",
+        patient_id="p1", facility_id="f1", response_status="Pending",
+    )
+
+    _, sent_params = fake.get_calls[0]
+    assert sent_params == {
+        "patient_id": "p1", "facility_id": "f1", "response_status": "Pending",
+        "from_member_id": "1", "to_internal_member_id": "2", "to_external_member_id": "3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_in_filter_params_use_confirmed_names(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={"/referrals/in": {"referralin": []}})
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="list", direction="in",
+        to_member="1", from_internal_member="2", from_external_member="3",
+    )
+
+    _, sent_params = fake.get_calls[0]
+    assert sent_params == {
+        "to_member_id": "1", "from_internal_member_id": "2", "from_external_member_id": "3",
+    }
+
+
+# ── get ────────────────────────────────────────────────────────────────
+# CONFIRMED LIVE (2026-08-11): the response is NOT flat — fields nest one
+# level under "referral_out"/"referral_in", alongside "code"/"message".
+
+
+@pytest.mark.asyncio
+async def test_get_out_unwraps_nested_fields(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/out/999": _get_out({"ref_id": "999", "patient_id": "p1"}),
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="get", direction="out", referral_id="999")
+
+    assert result["ref_id"] == "999"
+    assert result["patient_id"] == "p1"
+    assert result["guidance"] == "Referral retrieved."
+    assert "code" not in result and "message" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_in_unwraps_nested_fields(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/in/500": _get_in({"ref_in_id": "500", "patient_id": "p1"}),
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="get", direction="in", referral_id="500")
+
+    assert result["ref_in_id"] == "500"
+
+
+@pytest.mark.asyncio
+async def test_get_missing_referral_id_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(action="get", direction="out")
+
+    assert json.loads(str(exc_info.value))["error"] == "referral_id required for get"
+
+
+# ── update ─────────────────────────────────────────────────────────────
+# The real backend does a full row overwrite, not a partial patch (confirmed
+# live: omitting to_internal_member wiped it to null). update fetches the
+# existing referral first (unwrapping get's nesting — the actual root cause
+# of "update needs undocumented fields", previously misdiagnosed as staleness)
+# and merges caller-supplied fields on top of it, then re-fetches afterward
+# for an authoritative result rather than trusting the PUT response's body.
+
+
+@pytest.mark.asyncio
+async def test_update_out_merges_omitted_fields_from_existing_record(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "to_internal_member_id": "2",
+                "referral_date": "2026-08-06",
+                "priority": "Normal", "referral_reason": "Follow-up",
+                "response_status": "Pending",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    # Caller only wants to change priority — everything else should be
+    # pulled from the existing record, not sent as null/omitted.
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["priority"] == "Urgent"
+    assert sent_body["facility_id"] == "f1"
+    assert sent_body["from_member"] == "1"
+    assert sent_body["to_internal_member"] == "2"
+    assert sent_body["patient_id"] == "p1"
+    assert sent_body["referral_reason"] == "Follow-up"
+    assert sent_body["response_status"] == "Pending"
+
+
+@pytest.mark.asyncio
+async def test_update_out_fails_cleanly_if_required_fields_absent_everywhere(monkeypatch) -> None:
+    """facility_id/from_member/patient_id are read with a bare .asLong() and
+    no null check server-side — omitting them throws an opaque 500. If the
+    merge can't fill them in from the existing record either, fail before
+    ever calling PUT."""
+    fake = _FakeAPIClient(get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})})
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(action="update", direction="out", referral_id="999")
+
+    assert "facility_id, from_member, and patient_id" in json.loads(str(exc_info.value))["error"]
+    assert fake.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_fails_cleanly_if_referral_date_absent_everywhere(monkeypatch) -> None:
+    """updateReferralJSON/updateReferralInJSON both declare referral_date
+    min-occurrences="1" — schema-required on both directions, independent of
+    the facility_id/from_member/patient_id check above. Must fail before
+    calling PUT if the merge can't backfill it either."""
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/out/999": _get_out({"ref_id": "999", "facility_id": "f1", "from_member_id": "1", "patient_id": "p1"}),
+    })
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(action="update", direction="out", referral_id="999")
+
+    assert "referral_date" in json.loads(str(exc_info.value))["error"]
+    assert fake.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_in_fails_cleanly_if_facility_id_absent_everywhere(monkeypatch) -> None:
+    """facility_id is schema-required for 'in' update too, despite having no
+    effect on the row — must fail before calling PUT if unfillable."""
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/in/500": _get_in({"ref_in_id": "500", "patient_id": "p1", "referral_date": "2026-08-01"}),
+    })
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(action="update", direction="in", referral_id="500")
+
+    assert "facility_id" in json.loads(str(exc_info.value))["error"]
+    assert fake.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_in_ignores_facility_id_value_but_still_requires_it_present(monkeypatch) -> None:
+    """updateReferralIn's facility_id read is dead code server-side (has zero
+    effect on the row) but the API's request SCHEMA still requires the key to
+    be present (min-occurrences="1") — a field can be schema-required without
+    the business logic ever using its value. Same for referral_date on both
+    directions. The merge fills both from the existing record automatically."""
+    fake = _FakeAPIClient(
+        get_responses={"/referrals/in/500": _get_in({
+            "ref_in_id": "500", "patient_id": "p1", "facility_id": "f1",
+            "referral_date": "2026-08-01",
+        })},
+        put_responses={"/referrals/in/500": _mutation({"ref_in_id": "500"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="in", referral_id="500", priority="Urgent",
+    )
+
+    assert result["guidance"] == "Referral updated."
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["patient_id"] == "p1"
+    assert sent_body["facility_id"] == "f1"
+    assert sent_body["referral_date"] == "2026-08-01"
+    assert sent_body["priority"] == "Urgent"
+
+
+@pytest.mark.asyncio
+async def test_update_fails_if_fetching_existing_record_errors(monkeypatch) -> None:
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/out/999": {"error": "HTTP 404: not found"},
+    })
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="update", direction="out", referral_id="999",
+            facility_id="f1", from_member="1", patient_id="p1",
+        )
+
+    assert "Could not fetch the existing referral" in json.loads(str(exc_info.value))["guidance"]
+    assert fake.put_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_trusts_verify_get_over_put_response_echo(monkeypatch) -> None:
+    """Same unreliable-echo issue as create — CONFIRMED LIVE a PUT that left
+    from_member unchanged at ...117 echoed back ...110 in its own response; an
+    immediate GET correctly showed ...117 still persisted. update must return
+    the verify-GET's data, not the PUT response's."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": [
+                _get_out({  # pre-update existing-record fetch
+                    "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                    "from_member_id": "117", "referral_date": "2026-08-01",
+                }),
+                _get_out({  # post-update verify fetch — authoritative
+                    "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                    "from_member_id": "117", "referral_date": "2026-08-01", "priority": "Urgent",
+                }),
+            ],
+        },
+        put_responses={
+            "/referrals/out/999": _mutation({"ref_id": "999", "from_member": "110"}),  # unreliable echo
+        },
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    assert result["from_member_id"] == "117"
+    assert result["priority"] == "Urgent"
+
+
+@pytest.mark.asyncio
+async def test_update_success_path_does_not_surface_notes_fields_at_all(monkeypatch) -> None:
+    """When the post-update verify-GET succeeds (the normal case), the result
+    reflects "get"'s real shape, which never includes referral_notes/
+    response_notes at all — no garbling, no masking note needed, they're
+    just absent."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "referral_date": "2026-08-01", "priority": "Urgent",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    assert "referral_notes" not in result
+    assert "_notes_fields_note" not in result
+    assert result["priority"] == "Urgent"
+
+
+@pytest.mark.asyncio
+async def test_update_response_masks_raw_notes_pointer_on_verify_fallback(monkeypatch) -> None:
+    """Fallback path: the pre-update existing-record fetch succeeds (needed to
+    pass validation), but the post-update verify-fetch fails, so this falls
+    back to the raw PUT response — which DOES include referral_notes — and
+    that raw value must still be masked."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": [
+                _get_out({
+                    "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                    "from_member_id": "1", "referral_date": "2026-08-01",
+                }),
+                {"error": "simulated verify failure"},
+            ],
+        },
+        put_responses={
+            "/referrals/out/999": _mutation({
+                "ref_id": "999",
+                "referral_notes": "1786019884879_referral.html!@>NN1:-4152206861348658358",
+            }),
+        },
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    assert result.get("referral_notes") is None
+    assert "internal file pointer" in result["_notes_fields_note"]
+
+
+@pytest.mark.asyncio
+async def test_update_missing_referral_id_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(action="update", direction="out")
+
+    assert json.loads(str(exc_info.value))["error"] == "referral_id required for update"
+    assert fake.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_in_rejects_completed(monkeypatch) -> None:
+    """update/in's real set is Pending|Received|Reviewed, NOT Pending|Completed
+    like create/respond use for "in" — confirmed against updateReferralInJSON's
+    own schema, documented as found rather than assumed consistent."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="update", direction="in", referral_id="500", response_status="Completed",
+        )
+
+    error_payload = json.loads(str(exc_info.value))
+    assert "not valid" in error_payload["error"]
+    assert "Received" in error_payload["guidance"]
+    assert fake.get_calls == []  # fails before ever fetching the existing record
+
+
+# ── respond ────────────────────────────────────────────────────────────
+# facility_id is confirmed REQUIRED for respond on both directions — enforced
+# by a request-level JSON-schema layer (security-api-referral.xml's
+# <jsontemplate name="addReferralResponseJSON"/"addReferralInResponseJSON">,
+# both declaring facility_id min-occurrences="1") that's separate from, and
+# invisible in, ReferralBeanImpl.addReferralResponse/addReferralInResponse's
+# Java body (which never reads facility_id at all). Found live: the API
+# rejected a real call with "Mandatory parameters missing: facility_id" even
+# though every field the Java method itself uses was present.
+#
+# NOTE (2026-08-11): live-testing found `respond` currently returns a generic
+# HTTP 500 on BOTH directions, on multiple different valid pre-existing
+# referrals — looks like a backend-side issue in that environment, not
+# something these tests (or any client-side fix) can address. The happy-path
+# tests below describe the INTENDED behavior once that's resolved.
+
+
+@pytest.mark.asyncio
+async def test_respond_out_trusts_verify_get_and_sends_correct_body(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        post_responses={
+            "/referrals/out/999/response": _mutation({"ref_id": "999", "response_status": "Pending"}),
+        },
+        get_responses={
+            "/referrals/out/999": _get_out({"ref_id": "999", "response_status": "Reviewed"}),
+        },
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        response_date=datetime.date(2026, 8, 7),
+        response_notes="Patient seen, no further action needed.",
+        response_status="Reviewed",
+    )
+
+    endpoint, sent_body = fake.post_calls[0]
+    assert endpoint == "/referrals/out/999/response"
+    assert sent_body == {
+        "facility_id": "f1",
+        "response_date": "2026-08-07",
+        "response_notes": "Patient seen, no further action needed.",
+        "response_status": "Reviewed",
+    }
+    assert result["response_status"] == "Reviewed"
+    assert result["guidance"] == "Response recorded."
+
+
+@pytest.mark.asyncio
+async def test_respond_missing_facility_id_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="respond", direction="out", referral_id="999", response_status="Reviewed",
+        )
+
+    assert json.loads(str(exc_info.value))["error"] == "facility_id required for respond"
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_respond_out_does_not_send_diagnoses(monkeypatch) -> None:
+    """addReferralResponse (out) never reads diagnoses at all — only
+    addReferralInResponse writes RESPONSE_DIAGNOSES. Sending it for "out"
+    would be silently ignored server-side, so don't send it."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out/999/response": _mutation({"ref_id": "999"})},
+        get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        response_status="Reviewed",
+        diagnoses=[{"name": "Hypertension", "code": "I10"}],
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert "diagnoses" not in sent_body
+
+
+@pytest.mark.asyncio
+async def test_respond_in_sends_diagnoses_and_notes_cascade_quirk(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/in/500/response": _mutation({"ref_in_id": "500"})},
+        get_responses={"/referrals/in/500": _get_in({"ref_in_id": "500"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="in", referral_id="500", facility_id="f1",
+        response_status="Completed",
+        diagnoses=[{"name": "Hypertension", "code": "I10"}],
+    )
+
+    _, sent_body = fake.post_calls[0]
+    assert sent_body["diagnoses"] == [{"name": "Hypertension", "code": "I10"}]
+    # The real backend cascades response_date/response_notes onto a linked
+    # internal outbound record and force-sets ITS status to "To Be Reviewed"
+    # regardless of what was passed here — the guidance must warn about this
+    # so a caller doesn't assume only the "in" record changed.
+    assert "To Be Reviewed" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_respond_missing_referral_id_returns_clean_error(monkeypatch) -> None:
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(action="respond", direction="out")
+
+    assert json.loads(str(exc_info.value))["error"] == "referral_id required for respond"
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_respond_no_content_returns_clean_error(monkeypatch) -> None:
+    """facility_id alone isn't a response — must still require real content."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="respond", direction="out", referral_id="999", facility_id="f1",
+        )
+
+    assert json.loads(str(exc_info.value))["error"] == "No response content provided"
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_respond_response_masks_raw_notes_pointer_on_verify_fallback(monkeypatch) -> None:
+    """RESPONSE_NOTES uses the same raw-file-pointer storage as
+    REFERRAL_NOTES — only reachable via the verify-GET-fails fallback path
+    (the real "get" entity never returns response_notes either)."""
+    fake = _FakeAPIClient(
+        post_responses={
+            "/referrals/out/999/response": _mutation({
+                "ref_id": "999",
+                "response_notes": "1786019884879_response.html!@>NN1:-4152206861348658358",
+            }),
+        },
+        get_responses={"/referrals/out/999": {"error": "simulated verify failure"}},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        response_notes="Patient seen, cleared for surgery.",
+    )
+
+    assert result.get("response_notes") is None
+    assert "internal file pointer" in result["_notes_fields_note"]
+
+
+# ── response_status validation ──────────────────────────────────────────
+# The valid set genuinely differs per (direction, action) — confirmed against
+# security-api-referral.xml's <jsontemplate> regexes. Validated client-side so
+# an invalid value gets a helpful error instead of the API's generic
+# "HTTP 400: Invalid value passed for response_status".
+
+
+@pytest.mark.asyncio
+async def test_respond_out_rejects_received_lists_valid_values(monkeypatch) -> None:
+    """"Received" is valid for create/update/out but NOT for respond/out —
+    respond's own set is Pending|To Be Reviewed|Reviewed."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="respond", direction="out", referral_id="999", facility_id="f1",
+            response_status="Received",
+        )
+
+    error_payload = json.loads(str(exc_info.value))
+    assert "not valid" in error_payload["error"]
+    assert "To Be Reviewed" in error_payload["guidance"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_respond_out_accepts_to_be_reviewed(monkeypatch) -> None:
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out/999/response": _mutation({"ref_id": "999"})},
+        get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        response_status="To Be Reviewed",
+    )
+
+    assert result["guidance"] == "Response recorded."
+
+
+@pytest.mark.asyncio
+async def test_respond_in_rejects_reviewed(monkeypatch) -> None:
+    """respond/in's set is Pending|Completed — "Reviewed" (valid for out) isn't."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="respond", direction="in", referral_id="500", facility_id="f1",
+            response_status="Reviewed",
+        )
+
+    assert "Pending" in json.loads(str(exc_info.value))["guidance"]
+    assert fake.post_calls == []

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -133,6 +133,18 @@ def test_unwrap_mutation_response_falls_back_on_unexpected_shape() -> None:
     assert referrals._unwrap_mutation_response(flat) == flat
 
 
+def test_unwrap_get_response_wraps_non_dict_response() -> None:
+    """Both unwrap helpers are declared -> Dict[str, Any] but previously
+    returned a non-dict response unchanged when it didn't match the expected
+    shape — every caller does `result["guidance"] = ...` on the return
+    value, which would raise. Must always return a dict."""
+    assert referrals._unwrap_get_response([1, 2, 3], "out") == {"raw_response": [1, 2, 3]}
+
+
+def test_unwrap_mutation_response_wraps_non_dict_response() -> None:
+    assert referrals._unwrap_mutation_response([1, 2, 3]) == {"raw_response": [1, 2, 3]}
+
+
 # ── create ─────────────────────────────────────────────────────────────
 
 
@@ -331,6 +343,27 @@ async def test_create_diagnoses_rejects_malformed_json_string(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_create_diagnoses_rejects_non_dict_list_elements(monkeypatch) -> None:
+    """Same gap _parse_order_tests had (charm-mcp-server's managePatientLabs)
+    before its own fix in this PR — `diagnoses=["Hypertension"]` parses as
+    valid JSON and IS a list, so a list-only check passes it through to the
+    real API instead of failing clean client-side."""
+    fake = _FakeAPIClient()
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="create", direction="out",
+            facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+            from_member="1", to_internal_member="2",
+            diagnoses=["Hypertension"],
+        )
+
+    assert "diagnoses" in json.loads(str(exc_info.value))["error"]
+    assert fake.post_calls == []
+
+
+@pytest.mark.asyncio
 async def test_create_out_rejects_to_be_reviewed(monkeypatch) -> None:
     """"To Be Reviewed" is respond/out's set, not create's — create/update/out
     use Pending|Received|Reviewed."""
@@ -412,6 +445,22 @@ async def test_list_no_results_reports_correctly(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_survives_wrapper_key_present_but_null(monkeypatch) -> None:
+    """`.get(wrapper_key, [])` only supplies the default when the key is
+    absent, not when the API sends it explicitly null for a zero-result
+    response — a real possibility given how many other response-shape
+    surprises this same API has produced (see this file's other
+    "CONFIRMED LIVE" comments). Must not raise on `for r in referrals`."""
+    fake = _FakeAPIClient(get_responses={"/referrals/out": {"referralout": None}})
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="list", direction="out")
+
+    assert result["total_count"] == 0
+    assert result["referrals"] == []
+
+
+@pytest.mark.asyncio
 async def test_list_out_filter_params_use_confirmed_names(monkeypatch) -> None:
     """Confirmed directly against CharmTemplateHandler's criteria-resolver
     code — from_member_id/to_internal_member_id/to_external_member_id, not
@@ -430,6 +479,20 @@ async def test_list_out_filter_params_use_confirmed_names(monkeypatch) -> None:
         "patient_id": "p1", "facility_id": "f1", "response_status": "Pending",
         "from_member_id": "1", "to_internal_member_id": "2", "to_external_member_id": "3",
     }
+
+
+@pytest.mark.asyncio
+async def test_list_sends_explicit_page_and_per_page_zero(monkeypatch) -> None:
+    """`if page:`/`if per_page:` (truthiness) would silently drop an explicit
+    0 — same bug class as the quantity=0 fix elsewhere in this PR."""
+    fake = _FakeAPIClient(get_responses={"/referrals/out": {"referralout": []}})
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(action="list", direction="out", page=0, per_page=0)
+
+    _, sent_params = fake.get_calls[0]
+    assert sent_params["page"] == 0
+    assert sent_params["per_page"] == 0
 
 
 @pytest.mark.asyncio
@@ -506,6 +569,21 @@ async def test_get_masks_raw_notes_pointer(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_survives_non_dict_response(monkeypatch) -> None:
+    """Same non-dict-response risk as create (see
+    test_create_survives_non_dict_mutation_response) — a non-dict response
+    must not crash `result["guidance"] = ...`. A bare string, not a list, to
+    avoid _FakeAPIClient.get's own list-of-sequential-responses convention."""
+    fake = _FakeAPIClient(get_responses={"/referrals/out/999": "unexpected-response-shape"})
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="get", direction="out", referral_id="999")
+
+    assert "error" not in result
+    assert result["raw_response"] == "unexpected-response-shape"
+
+
+@pytest.mark.asyncio
 async def test_get_in_unwraps_nested_fields(monkeypatch) -> None:
     fake = _FakeAPIClient(get_responses={
         "/referrals/in/500": _get_in({"ref_in_id": "500", "patient_id": "p1"}),
@@ -567,6 +645,35 @@ async def test_update_out_merges_omitted_fields_from_existing_record(monkeypatch
     assert sent_body["patient_id"] == "p1"
     assert sent_body["referral_reason"] == "Follow-up"
     assert sent_body["response_status"] == "Pending"
+
+
+@pytest.mark.asyncio
+async def test_update_survives_non_dict_verify_and_mutation_response(monkeypatch) -> None:
+    """Same non-dict-response risk as create — if both the verify-GET and the
+    PUT's own response come back non-dict-shaped, `result["guidance"] = ...`
+    must not crash into a false "could not update", whose natural retry
+    would mean overwriting the referral again unnecessarily."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": [
+                _get_out({
+                    "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                    "from_member_id": "1", "referral_date": "2026-08-06",
+                }),
+                [1, 2, 3],
+            ],
+        },
+        put_responses={"/referrals/out/999": [1, 2, 3]},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    assert "error" not in result
+    assert result["raw_response"] == [1, 2, 3]
+    assert result["guidance"] == "Referral updated."
 
 
 @pytest.mark.asyncio
@@ -894,6 +1001,27 @@ async def test_respond_out_trusts_verify_get_and_sends_correct_body(monkeypatch)
         "response_status": "Reviewed",
     }
     assert result["response_status"] == "Reviewed"
+    assert result["guidance"] == "Response recorded."
+
+
+@pytest.mark.asyncio
+async def test_respond_survives_non_dict_verify_and_mutation_response(monkeypatch) -> None:
+    """Same non-dict-response risk as create/update, on respond. A bare
+    string, not a list, to avoid _FakeAPIClient.get's own
+    list-of-sequential-responses convention."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out/999/response": "unexpected-response-shape"},
+        get_responses={"/referrals/out/999": "unexpected-response-shape"},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        response_status="Reviewed",
+    )
+
+    assert "error" not in result
+    assert result["raw_response"] == "unexpected-response-shape"
     assert result["guidance"] == "Response recorded."
 
 

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -404,6 +404,24 @@ async def test_list_in_filter_params_use_confirmed_names(monkeypatch) -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_list_rejects_response_status_invalid_for_this_direction(monkeypatch) -> None:
+    """"Completed" is valid for direction="in" but not direction="out" (out's list set is
+    Pending/Reviewed/To Be Reviewed). Previously this validation was never run for "list"
+    at all — the invalid filter went straight to the API's query params, which would
+    silently produce a misleading empty result instead of a clear error."""
+    fake = _FakeAPIClient(get_responses={"/referrals/out": {"referralout": []}})
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="list", direction="out", response_status="Completed",
+        )
+
+    assert "response_status" in json.loads(str(exc_info.value))["error"]
+    assert fake.get_calls == []
+
+
 # ── get ────────────────────────────────────────────────────────────────
 # CONFIRMED LIVE (2026-08-11): the response is NOT flat — fields nest one
 # level under "referral_out"/"referral_in", alongside "code"/"message".
@@ -486,6 +504,60 @@ async def test_update_out_merges_omitted_fields_from_existing_record(monkeypatch
     assert sent_body["patient_id"] == "p1"
     assert sent_body["referral_reason"] == "Follow-up"
     assert sent_body["response_status"] == "Pending"
+
+
+@pytest.mark.asyncio
+async def test_update_out_drops_response_status_invalid_for_update_from_merge(monkeypatch) -> None:
+    """The existing referral's response_status ("To Be Reviewed") was set by a prior
+    respond() call — valid for direction="out" action="respond", but NOT in update's own
+    narrower set (Pending/Received/Reviewed). The caller only wants to change priority and
+    never touched response_status — merging the existing value in unvalidated would send a
+    value update's own schema rejects, failing over a field the caller didn't ask about.
+    Must be dropped from the outgoing body instead."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/out/999": _get_out({
+                "ref_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "from_member_id": "1", "to_internal_member_id": "2",
+                "referral_date": "2026-08-06", "priority": "Normal",
+                "response_status": "To Be Reviewed",
+            }),
+        },
+        put_responses={"/referrals/out/999": _mutation({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="out", referral_id="999", priority="Urgent",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert sent_body["priority"] == "Urgent"
+    assert "response_status" not in sent_body
+
+
+@pytest.mark.asyncio
+async def test_update_in_drops_response_status_invalid_for_update_from_merge(monkeypatch) -> None:
+    """Same fix, direction="in": "Completed" is valid for create/respond but not for
+    update's own set (Pending/Received/Reviewed)."""
+    fake = _FakeAPIClient(
+        get_responses={
+            "/referrals/in/999": _get_in({
+                "ref_in_id": "999", "patient_id": "p1", "facility_id": "f1",
+                "to_member_id": "1", "referral_date": "2026-08-06",
+                "response_status": "Completed",
+            }),
+        },
+        put_responses={"/referrals/in/999": _mutation({"ref_in_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    await referrals.manageReferrals.fn(
+        action="update", direction="in", referral_id="999", priority="Urgent",
+    )
+
+    _, sent_body = fake.put_calls[0]
+    assert "response_status" not in sent_body
 
 
 @pytest.mark.asyncio

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -570,13 +570,18 @@ async def test_update_out_merges_omitted_fields_from_existing_record(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_update_out_drops_response_status_invalid_for_update_from_merge(monkeypatch) -> None:
+async def test_update_out_fails_when_merged_response_status_invalid_for_update(monkeypatch) -> None:
     """The existing referral's response_status ("To Be Reviewed") was set by a prior
     respond() call — valid for direction="out" action="respond", but NOT in update's own
     narrower set (Pending/Received/Reviewed). The caller only wants to change priority and
-    never touched response_status — merging the existing value in unvalidated would send a
-    value update's own schema rejects, failing over a field the caller didn't ask about.
-    Must be dropped from the outgoing body instead."""
+    never touched response_status.
+
+    Dropping it from the outgoing body (the earlier fix) is NOT safe for direction="out":
+    confirmed against ReferralBeanImpl.updateReferralOut, row.set("RESPONSE_STATUS",
+    resStatus) runs unconditionally even when the key is absent from the request (resStatus
+    stays null in that branch) — omitting it would silently null the column instead of
+    leaving it untouched. Must fail instead, naming the stored value, and let the caller
+    decide."""
     fake = _FakeAPIClient(
         get_responses={
             "/referrals/out/999": _get_out({
@@ -590,19 +595,22 @@ async def test_update_out_drops_response_status_invalid_for_update_from_merge(mo
     )
     _patch_client(monkeypatch, fake)
 
-    await referrals.manageReferrals.fn(
-        action="update", direction="out", referral_id="999", priority="Urgent",
-    )
+    with pytest.raises(ToolError) as exc_info:
+        await referrals.manageReferrals.fn(
+            action="update", direction="out", referral_id="999", priority="Urgent",
+        )
 
-    _, sent_body = fake.put_calls[0]
-    assert sent_body["priority"] == "Urgent"
-    assert "response_status" not in sent_body
+    assert "To Be Reviewed" in json.loads(str(exc_info.value))["error"]
+    assert fake.put_calls == []
 
 
 @pytest.mark.asyncio
 async def test_update_in_drops_response_status_invalid_for_update_from_merge(monkeypatch) -> None:
-    """Same fix, direction="in": "Completed" is valid for create/respond but not for
-    update's own set (Pending/Received/Reviewed)."""
+    """"Completed" is valid for create/respond but not for update's own set
+    (Pending/Received/Reviewed) — same mismatch as the "out" case, but here dropping is
+    safe rather than failing: updateReferralIn's row.set("RESPONSE_STATUS", resStatus) is
+    commented out server-side, so the field is dead and omitting it doesn't touch the
+    stored value."""
     fake = _FakeAPIClient(
         get_responses={
             "/referrals/in/999": _get_in({

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -182,6 +182,30 @@ async def test_create_falls_back_to_mutation_response_if_verify_get_fails(monkey
 
 
 @pytest.mark.asyncio
+async def test_create_survives_non_dict_mutation_response(monkeypatch) -> None:
+    """If the create POST returns something that isn't a dict (e.g. a bare
+    array), _unwrap_mutation_response passes it through unchanged. Subscripting
+    it directly (`created["guidance"] = ...`) would raise, and the generic
+    exception handler would then report "Could not create" for a referral
+    that was, in fact, created — the natural response to that false failure
+    is a retry, which duplicates it. Must degrade to a dict instead of
+    raising."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out": [{"ref_id": "999"}]},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="create", direction="out",
+        facility_id="f1", referral_date=datetime.date(2026, 8, 6),
+        from_member="1", to_internal_member="2",
+    )
+
+    assert "error" not in result
+    assert result["raw_response"] == [{"ref_id": "999"}]
+
+
+@pytest.mark.asyncio
 async def test_create_out_missing_facility_or_date_returns_clean_error(monkeypatch) -> None:
     fake = _FakeAPIClient()
     _patch_client(monkeypatch, fake)
@@ -357,6 +381,26 @@ async def test_list_in_reads_the_real_wrapper_key(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_masks_raw_notes_pointer_per_item(monkeypatch) -> None:
+    """Same gap as "get" — "list" previously skipped _mask_notes_pointer,
+    so a raw DFS file pointer in any listed referral's referral_notes could
+    reach the LLM. Must be masked per-item, not just on the outer wrapper."""
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/out": {"referralout": [
+            {"ref_id": "1", "referral_notes": "1786019884879_referral.html!@>NN1:-4152206861348658358"},
+            {"ref_id": "2"},
+        ]},
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="list", direction="out")
+
+    assert result["referrals"][0].get("referral_notes") is None
+    assert "_notes_fields_note" in result["referrals"][0]
+    assert "_notes_fields_note" not in result["referrals"][1]
+
+
+@pytest.mark.asyncio
 async def test_list_no_results_reports_correctly(monkeypatch) -> None:
     fake = _FakeAPIClient(get_responses={"/referrals/out": {"referralout": []}})
     _patch_client(monkeypatch, fake)
@@ -440,6 +484,25 @@ async def test_get_out_unwraps_nested_fields(monkeypatch) -> None:
     assert result["patient_id"] == "p1"
     assert result["guidance"] == "Referral retrieved."
     assert "code" not in result and "message" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_masks_raw_notes_pointer(monkeypatch) -> None:
+    """Unlike create/update/respond, "get" previously skipped
+    _mask_notes_pointer entirely — a raw DFS file pointer (not real note
+    text) could reach the LLM as if it were referral_notes content."""
+    fake = _FakeAPIClient(get_responses={
+        "/referrals/out/999": _get_out({
+            "ref_id": "999",
+            "referral_notes": "1786019884879_referral.html!@>NN1:-4152206861348658358",
+        }),
+    })
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(action="get", direction="out", referral_id="999")
+
+    assert result.get("referral_notes") is None
+    assert "_notes_fields_note" in result
 
 
 @pytest.mark.asyncio
@@ -844,14 +907,18 @@ async def test_respond_missing_facility_id_returns_clean_error(monkeypatch) -> N
 async def test_respond_out_does_not_send_diagnoses(monkeypatch) -> None:
     """addReferralResponse (out) never reads diagnoses at all — only
     addReferralInResponse writes RESPONSE_DIAGNOSES. Sending it for "out"
-    would be silently ignored server-side, so don't send it."""
+    would be silently ignored server-side, so don't send it. Since the call
+    still succeeds on its other content (response_status here), the caller
+    must be warned diagnoses was dropped — a clinical write reporting bare
+    success for a partial write is worse than an error, because nothing
+    downstream would otherwise notice the diagnoses never landed."""
     fake = _FakeAPIClient(
         post_responses={"/referrals/out/999/response": _mutation({"ref_id": "999"})},
         get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})},
     )
     _patch_client(monkeypatch, fake)
 
-    await referrals.manageReferrals.fn(
+    result = await referrals.manageReferrals.fn(
         action="respond", direction="out", referral_id="999", facility_id="f1",
         response_status="Reviewed",
         diagnoses=[{"name": "Hypertension", "code": "I10"}],
@@ -859,6 +926,26 @@ async def test_respond_out_does_not_send_diagnoses(monkeypatch) -> None:
 
     _, sent_body = fake.post_calls[0]
     assert "diagnoses" not in sent_body
+    assert "WARNING" in result["guidance"]
+    assert "diagnoses" in result["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_respond_out_without_diagnoses_has_no_warning(monkeypatch) -> None:
+    """The new diagnoses-dropped warning must only fire when the caller
+    actually passed diagnoses — not on every direction="out" respond."""
+    fake = _FakeAPIClient(
+        post_responses={"/referrals/out/999/response": _mutation({"ref_id": "999"})},
+        get_responses={"/referrals/out/999": _get_out({"ref_id": "999"})},
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = await referrals.manageReferrals.fn(
+        action="respond", direction="out", referral_id="999", facility_id="f1",
+        response_status="Reviewed",
+    )
+
+    assert "WARNING" not in result["guidance"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Summary**

Implements CH-733 subtask 1: new `manageReferrals` tool, `order` on `managePatientLabs`, `prescribe` on `managePatientDrugs`. All three live-tested end-to-end against the real sandbox (real referrals created, a real lab order placed, a real prescription written).

- **`manageReferrals`** — `create`/`list`/`get`/`update`/`respond` for both directions. Handles real backend quirks: double-nested mutation responses, unreliable party-member echo fields, notes fields being file pointers not text, and per-direction `response_status` enums. 

> respond initially failed near-universally with a generic 500 in testing — traced (via review) to patient_id never being sent: addAttachmentsToRO dereferences it unconditionally on both directions and NPEs without it. Fixed: patient_id is now required and sent, confirmed live end-to-end. update("out") still fails with zf.api.inavalid.id.provided in this sandbox — believed to be a single-provider-account limitation (from_member/to_internal_member collide when there's only one provider), not reproduced as a code defect, but not independently confirmed against a second account either; flagging as a known open issue rather than asserting it's resolved.

- **`order` on `managePatientLabs`** — places a real order given real catalog IDs, validated client-side first. The catalog-lookup actions (`search_labs`/`search_tests`) were built then removed — both need an OAuth scope (`defaults`) this app doesn't have, confirmed not fixable client-side and not part of the ticket ask.

- **`prescribe` on `managePatientDrugs`** — shares the `add` path, gated on `encounter_id`. `route`/`dose_form`/`dosage_unit` validated against the real backend's enum sets before the API call.

- **`api_client.py` fix** — a scope-blocked 401 was retried up to `max_retries` times, each retry wiping the shared token cache and taking down unrelated tools. Now retries once per request; a failed refresh returns a clean error instead of an unhandled exception.

**Test plan**

- `test_referrals.py`, `test_labs.py`, `test_api_client.py` (all new) plus full suite: 139 passed.
- Live-tested against real sandbox data: referral create/list/get, real lab order placement, real prescription write.
- Note: `search_labs`/`search_tests`/`managePatientDrugs.search` need the `defaults` OAuth scope added to this app's registration before they'd work — documented in `docs/issues.md`, out of scope for this PR to fix.