### PR TITLE
[CH-817] Add two-hop ID regression test for get_responses

### DIFF
--- a/tests/test_intake_forms.py
+++ b/tests/test_intake_forms.py
@@ -250,14 +250,69 @@ async def test_share_portal_missing_facility_id_raises_tool_error(monkeypatch) -
 
 @pytest.mark.asyncio
 async def test_get_responses_happy_path(monkeypatch) -> None:
+    # Real wrapper shape confirmed 2026-09-07 against a live completed
+    # submission: top-level "questionnaire_with_answers", questions carry
+    # entry_id/notes/notes_type/is_mandatory, and "answer" is present only
+    # on answered questions (absent, not null, on e.g. Label rows).
     fake = _FakeAPIClient(get_responses={
-        "/questionnaire/answer/a1": {"answers": []},
+        "/questionnaire/answer/a1": {"questionnaire_with_answers": {
+            "questionnaire_type": "Pre-screening Form",
+            "template_name": "Screen",
+            "is_submitted": True,
+            "patient_id": "p1",
+            "template_id": "t1",
+            "ques_map_id": "a1",
+            "questions": [
+                {"entry_id": "e1", "notes_type": "Label", "notes": "Welcome", "is_mandatory": False, "position": 0},
+                {"entry_id": "e2", "notes_type": "Question", "notes": "How are you?", "answer": "sdf", "is_mandatory": False, "position": 1},
+            ],
+        }},
     })
     _patch_client(monkeypatch, fake)
 
     result = await intake_forms.manageIntakeForms.fn(action="get_responses", answer_id="a1")
 
     assert "Responses retrieved" in result["guidance"]
+    questions = result["questionnaire_with_answers"]["questions"]
+    assert "answer" not in questions[0]
+    assert questions[1]["answer"] == "sdf"
+
+
+@pytest.mark.asyncio
+async def test_get_patient_forms_then_get_responses_uses_ques_map_id_not_questionnaire_id(monkeypatch) -> None:
+    """The two-hop trap the tool's own docstring warns about: get_responses
+    needs answer_id=ques_map_id (a specific patient/form assignment), not
+    questionnaire_id (the template). Deliberately give them different
+    values and only wire up the /questionnaire/answer/ endpoint under the
+    ques_map_id — threading questionnaire_id instead would KeyError inside
+    the tool's try/except and surface as an "error" response, not a
+    successful one, so this fails loudly if the wrong id is threaded."""
+    fake = _FakeAPIClient(get_responses={
+        "/patients/p1/questionnaires": {"patient_questionnaires": [
+            {"ques_map_id": "555", "questionnaire_id": "999", "is_submitted": "true"},
+        ]},
+        "/questionnaire/answer/555": {"questionnaire_with_answers": {
+            "questionnaire_type": "Pre-screening Form",
+            "template_name": "Screen",
+            "is_submitted": True,
+            "patient_id": "p1",
+            "template_id": "999",
+            "ques_map_id": "555",
+            "questions": [
+                {"entry_id": "e2", "notes_type": "Question", "notes": "How are you?", "answer": "sdf", "is_mandatory": False, "position": 1},
+            ],
+        }},
+        # Deliberately no "/questionnaire/answer/999" entry.
+    })
+    _patch_client(monkeypatch, fake)
+
+    forms_result = await intake_forms.manageIntakeForms.fn(action="get_patient_forms", patient_id="p1")
+    answer_id = forms_result["patient_questionnaires"][0]["ques_map_id"]
+
+    result = await intake_forms.manageIntakeForms.fn(action="get_responses", answer_id=answer_id)
+
+    assert "error" not in result
+    assert result["questionnaire_with_answers"]["ques_map_id"] == "555"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds a regression test for the ID-threading trap `manageIntakeForms`'s own docstring already warns about: `get_responses` takes `answer_id=ques_map_id` (a specific patient/form assignment), not `questionnaire_id` (the template). No test previously caught calling it with the wrong ID.

## Changes

- `test_get_patient_forms_then_get_responses_uses_ques_map_id_not_questionnaire_id` — calls `get_patient_forms`, pulls `ques_map_id` off the result, threads it into `get_responses`. The fake API client deliberately gives `ques_map_id` and `questionnaire_id` different values and only wires up the endpoint under the correct one — threading `questionnaire_id` instead would `KeyError` inside the tool's try/except and surface as an `"error"` response, so this fails loudly on the wrong ID rather than silently passing.
- Refreshed `test_get_responses_happy_path`'s fixture to match the real response shape — confirmed against a live completed submission (2026-09-07): top-level `questionnaire_with_answers` key, each question carries `entry_id`/`notes`/`notes_type`/`is_mandatory`, and `answer` is present only on answered questions (absent, not `null`, on e.g. `Label` rows). The old fixture (`{"answers": []}`) didn't match anything real.

This is the charm-mcp-server half of CH-817 (cortex-side intake capture depends on this shape being accurate — see the cortex PR). Landing it standalone since it's a pure test/fixture fix with no tool behavior change.

## Test plan

- [x] `pytest tests/test_intake_forms.py -v` — new test + refreshed fixture pass
- [x] Full non-live suite green (44 pre-existing `tests/test_api/*` failures are live-sandbox-state-dependent, unrelated — confirmed via `git status` that only this file changed)